### PR TITLE
Fix for safe parsing default value for tracks and sources

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -98,7 +98,7 @@ public class Util {
                     if (sourceProp.hasKey("file")) {
                         String file = sourceProp.getString("file");
                         String label = sourceProp.getString("label");
-                        boolean isDefault = sourceProp.getBoolean("default");
+                        boolean isDefault = sourceProp.hasKey("default") ? sourceProp.getBoolean("default") : false;
                         MediaSource source = new MediaSource.Builder().file(file).label(label).isDefault(isDefault).build();
                         sources.add(source);
                     }
@@ -147,7 +147,7 @@ public class Util {
                     if (trackProp.hasKey("file")) {
                         String file = trackProp.getString("file");
                         String label = trackProp.getString("label");
-                        boolean isDefault = trackProp.getBoolean("default");
+                        boolean isDefault = trackProp.hasKey("default") ? trackProp.getBoolean("default") : false;
                         Caption caption = new Caption.Builder().file(file).label(label).kind(CaptionType.CAPTIONS).isDefault(isDefault).build();
                         tracks.add(caption);
                     }


### PR DESCRIPTION
### What does this Pull Request do?
- Fixes potential crashes when not specifying the `default` prop on `sources` and `tracks` objects

### Why is this Pull Request needed?
- To fix crashes

### Are there any points in the code the reviewer needs to double check?
- No

### Are there any Pull Requests open in other repos which need to be merged with this?
- No

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/10)
