### PR TITLE
Fix all tracks are being marked captions

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -153,6 +153,7 @@ public class Util {
                         if (trackProp.hasKey("kind")) {
                             kind = getCaptionType(trackProp.getString("kind").toUpperCase(Locale.US));
                         }
+                        Caption caption = new Caption.Builder().file(file).label(label).kind(kind).isDefault(isDefault).build();
                         boolean isDefault = trackProp.hasKey("default") ? trackProp.getBoolean("default") : false;
                         tracks.add(caption);
                     }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -98,7 +98,7 @@ public class Util {
                     if (sourceProp.hasKey("file")) {
                         String file = sourceProp.getString("file");
                         String label = sourceProp.getString("label");
-                        boolean isDefault = sourceProp.getBoolean("default");
+                        boolean isDefault = sourceProp.hasKey("default") ? sourceProp.getBoolean("default") : false;
                         MediaSource source = new MediaSource.Builder().file(file).label(label).isDefault(isDefault).build();
                         sources.add(source);
                     }
@@ -147,7 +147,7 @@ public class Util {
                     if (trackProp.hasKey("file")) {
                         String file = trackProp.getString("file");
                         String label = trackProp.getString("label");
-                        boolean isDefault = trackProp.getBoolean("default");
+                        boolean isDefault = trackProp.hasKey("default") ? trackProp.getBoolean("default") : false;
                         Caption caption = new Caption.Builder().file(file).label(label).kind(CaptionType.CAPTIONS).isDefault(isDefault).build();
                         tracks.add(caption);
                     }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Locale;
 
 public class Util {
 
@@ -147,8 +148,13 @@ public class Util {
                     if (trackProp.hasKey("file")) {
                         String file = trackProp.getString("file");
                         String label = trackProp.getString("label");
+                        CaptionType kind = CaptionType.CAPTIONS;
+                        // Being safe to old implementations though this should be required. 
+                        if (trackProp.hasKey("kind")) {
+                            kind = getCaptionType(trackProp.getString("kind").toUpperCase(Locale.US));
+                        }
                         boolean isDefault = trackProp.hasKey("default") ? trackProp.getBoolean("default") : false;
-                        Caption caption = new Caption.Builder().file(file).label(label).kind(CaptionType.CAPTIONS).isDefault(isDefault).build();
+                        Caption caption = new Caption.Builder().file(file).label(label).kind(kind).isDefault(isDefault).build();
                         tracks.add(caption);
                     }
                 }
@@ -184,6 +190,21 @@ public class Util {
         }
 
         return itemBuilder.build();
+    }
+
+    /**
+     * Internal helper for parsing a caption type from a known string
+     * @param type one of "CAPTIONS", "CHAPTERS", "THUMBNAILS"
+     * @return the correct Enum CaptionType
+     */
+    public static CaptionType getCaptionType(String type){
+        for (CaptionType captionType: CaptionType.values()) {
+            if (captionType.name().equals(type)) {
+                return CaptionType.valueOf(type);
+            }
+        }
+        // This should never happen. If a null is returned, expect a crash. Check `type` is specified type
+        return null;
     }
 
     public enum AdEventType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -216,7 +216,7 @@ declare module "@jwplayer/jwplayer-react-native" {
   interface JwTrack {
     id?: string;
     file?: string;
-    kind: string;
+    kind: TrackKind;
     label?: string;
     default?: boolean;
   }
@@ -251,9 +251,13 @@ declare module "@jwplayer/jwplayer-react-native" {
     label: string;
     default?: boolean;
   }
+
+  type TrackKind = "captions" | "chapters" | "thumbnails";
+
   interface Track {
     file: string;
     label: string;
+    kind: TrackKind;
     default?: boolean;
   }
   interface JWAdSettings {

--- a/index.js
+++ b/index.js
@@ -232,6 +232,8 @@ export default class JWPlayer extends Component {
 						PropTypes.shape({
 							file: PropTypes.string,
 							label: PropTypes.string,
+							kind: PropTypes.oneOf(['captions', 'thumbnails', 'chapters']),
+							default: PropTypes.bool
 						})
 					),
 					adSchedule: PropTypes.arrayOf(


### PR DESCRIPTION
### What does this Pull Request do?
- Start parsing for different tracks types from the `tracks` prop

### Why is this Pull Request needed?
- When using legacy props, there was no way to load in anything other than caption tracks

### Are there any points in the code the reviewer needs to double check?
- No, but since iOS doesn't require `kind`, we cannot make it required. This causes the need for the check if `kind` key exists. 

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/17)
