### PR TITLE
Implement onLoaded event for both platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Follow these steps to configure the media playback experience in your app:
       onPlayerError={event => this.onPlayerError(event)}
       onBuffer={() => this.onBuffer()}
       onTime={event => this.onTime(event)}
+      onLoaded={event => this.onLoaded(event)}
       onFullScreen={() => this.onFullScreen()}
       onFullScreenExit={() => this.onFullScreenExit()}
     />

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1269,6 +1269,13 @@ public class RNJWPlayerView extends RelativeLayout implements
             doBindService();
             requestAudioFocus();
         }
+        WritableMap onFirstFrame = Arguments.createMap();
+        onFirstFrame.putString("message", "onLoaded");
+        onFirstFrame.putDouble("loadTime", firstFrameEvent.getLoadTime());
+        getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(
+            getId(),
+            "topFirstFrame",
+            onFirstFrame);
     }
 
     @Override

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
@@ -159,6 +159,10 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
                     MapBuilder.of(
                             "phasedRegistrationNames",
                             MapBuilder.of("bubbled", "onCasting")))
+            .put("topFirstFrame",
+                    MapBuilder.of(
+                            "phasedRegistrationNames",
+                            MapBuilder.of("bubbled", "onLoaded")))
             .build();
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -486,6 +486,9 @@ declare module "@jwplayer/jwplayer-react-native" {
   interface PlaylistEventProps {
     playlist: PlaylistItem[]
   }
+  interface LoadEventProps {
+    loadTime: number;
+  }
   interface PlaylistItemEventProps {
     playlistItem: PlaylistItem
   }
@@ -511,6 +514,7 @@ declare module "@jwplayer/jwplayer-react-native" {
     forceLegacyConfig?: boolean;
     onPlayerReady?: () => void;
     onPlaylist?: (event: BaseEvent<PlaylistEventProps>) => void;
+    onLoaded? : (event: BaseEvent<LoadEventProps>) => void;
     onBeforePlay?: () => void;
     onBeforeComplete?: () => void;
     onComplete?: () => void;

--- a/index.js
+++ b/index.js
@@ -319,6 +319,7 @@ export default class JWPlayer extends Component {
 		}),
 		onPlayerReady: PropTypes.func,
 		onPlaylist: PropTypes.func,
+		onLoaded: PropTypes.func,
 		changePlaylist: PropTypes.func,
 		play: PropTypes.func,
 		pause: PropTypes.func,

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1192,7 +1192,7 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
     }
 
     func jwplayer(_ player:JWPlayer, didFinishLoadingWithTime loadTime:TimeInterval) {
-        self.onLoaded?([:])
+        self.onLoaded?(["loadTime":loadTime])
     }
 
     func jwplayer(_ player:JWPlayer, isAttemptingToPlay playlistItem:JWPlayerItem, reason:JWPlayReason) {

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -280,7 +280,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
 
     override func jwplayer(_ player:JWPlayer, didFinishLoadingWithTime loadTime:TimeInterval) {
         super.jwplayer(player, didFinishLoadingWithTime:loadTime)
-        parentView?.onLoaded?([:])
+        parentView?.onLoaded?(["loadTime":loadTime])
     }
 
     override func jwplayer(_ player:JWPlayer, isAttemptingToPlay playlistItem:JWPlayerItem, reason:JWPlayReason) {


### PR DESCRIPTION
### What does this Pull Request do?
- Expose `onLoaded` which is `onFirstFrame` for Android and `didFinishLoadingWithTime` for iOS.

### Why is this Pull Request needed?
- Provide a callback to access player in React as soon as it's loaded and ready.

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/29)
