### PR TITLE
chore: badge-maker as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
   "license": "MIT",
   "homepage": "https://github.com/jwplayer/jwplayer-react-native#readme",
   "devDependencies": {
+    "badge-maker": "^3.3.1",
     "lodash": ">= 4.17.21",
     "react": ">= 18.2.0",
     "react-native": ">= 0.72.5"
-  },
-  "dependencies": {
-    "badge-maker": "^3.3.1"
   }
 }


### PR DESCRIPTION
### What does this Pull Request do?
Makes badge-maker a dev dependency.

### Why is this Pull Request needed?
Reduces the number of dependencies added when installing the library.

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/37)
