### PR TITLE
feat: shrink bundle by replacing lodash with lodash.isequalwith

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import {
 	findNodeHandle,
 } from 'react-native';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import isEqualWith from 'lodash.isequalwith';
 
 const RNJWPlayerManager =
 	Platform.OS === 'ios'
@@ -389,7 +389,7 @@ export default class JWPlayer extends Component {
 		var { config, controls } = nextProps;
 		var thisConfig = this.props.config || {};
 
-		var result = !_.isEqualWith(
+		var result = !isEqualWith(
 			config,
 			thisConfig,
 			(value1, value2, key) => {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   "homepage": "https://github.com/jwplayer/jwplayer-react-native#readme",
   "devDependencies": {
     "badge-maker": "^3.3.1",
-    "lodash": ">= 4.17.21",
     "react": ">= 18.2.0",
     "react-native": ">= 0.72.5"
+  },
+  "dependencies": {
+    "lodash.isequalwith": "^4.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,15 +2505,15 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.isequalwith@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz#266726ddd528f854f21f4ea98a065606e0fbc6b0"
+  integrity sha512-dcZON0IalGBpRmJBmMkaoV7d3I80R2O+FrzsZyHdNSFrANq/cgDqKQNmAHE8UEj4+QYWwwhkQOVdLHiAopzlsQ==
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
-
-"lodash@>= 4.17.21":
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
### What does this Pull Request do?
Reduces the bundle size of the package by replacing lodash with `lodash.isequalwith`.

### Why is this Pull Request needed?
Lodash is among the largest dependencies in one representative app, this decreases the JavaScript bundle size by half a megabyte.

### Are there any points in the code the reviewer needs to double check?
This should in theory work identically, but may be worth checking that the `shouldComponentUpdate` check functions the same.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/41)
