### PR TITLE
fix: explicitly convert iOS volume to double

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -172,7 +172,7 @@ class RNJWPlayerViewManager: RCTViewManager {
         }
     }
     
-    @objc func setVolume(_ reactTag: NSNumber, _ volume: Double) {
+    @objc func setVolume(_ reactTag: NSNumber, _ volume: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? RNJWPlayerView else {
                 print("Invalid view returned from registry, expecting RNJWPlayerView, got: \(String(describing: viewRegistry?[reactTag]))")
@@ -180,9 +180,9 @@ class RNJWPlayerViewManager: RCTViewManager {
             }
 
             if let playerView = view.playerView {
-                playerView.player.volume = volume
+                playerView.player.volume = volume.doubleValue
             } else if let playerViewController = view.playerViewController {
-                playerViewController.player.volume = volume
+                playerViewController.player.volume = volume.doubleValue
             }
         }
     }


### PR DESCRIPTION
### What does this Pull Request do?
Fixes a suspected type conversion issue which made `setVolume` fail in some cases by explicitly converting `volume` to `double` from `NSNumber` (the type it's annotated in the React Native module) in Swift.

### Why is this Pull Request needed?
To prevent `setVolume` from failing.

### Are there any points in the code the reviewer needs to double check?
Someone who's more used to RN native development should double check me on this approach.

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/43)
