### PR TITLE
fix: prevent iOS crash when Google Cast is not enabled and React Native's new architecture is

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerViewManager.m
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.m
@@ -93,6 +93,8 @@ RCT_EXTERN_METHOD(setVolume: (nonnull NSNumber *)reactTag :(nonnull NSNumber *)v
 
 RCT_EXTERN_METHOD(togglePIP: (nonnull NSNumber *)reactTag)
 
+#if USE_GOOGLE_CAST
+
 RCT_EXTERN_METHOD(setUpCastController: (nonnull NSNumber *)reactTag)
 
 RCT_EXTERN_METHOD(presentCastDialog: (nonnull NSNumber *)reactTag)
@@ -102,6 +104,8 @@ RCT_EXTERN_METHOD(connectedDevice: (nonnull NSNumber *)reactTag :(RCTPromiseReso
 RCT_EXTERN_METHOD(availableDevices: (nonnull NSNumber *)reactTag: (RCTPromiseResolveBlock)resolve: (RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(castState: (nonnull NSNumber *)reactTag :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject)
+
+#endif
 
 RCT_EXTERN_METHOD(getAudioTracks: (nonnull NSNumber *)reactTag: (RCTPromiseResolveBlock)resolve: (RCTPromiseRejectBlock)reject)
 


### PR DESCRIPTION
### What does this Pull Request do?

Removes the cast methods from the list of methods exported to React Native on iOS when `USE_GOOGLE_CAST` is not enabled.

### Why is this Pull Request needed?

iOS apps without this crash on React Native's new architecture after being built with Google Cast support, because otherwise the code tries to reference missing methods.

### Are there any points in the code the reviewer needs to double check?

No.

### Are there any Pull Requests open in other repos which need to be merged with this?

No.

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/48)
