### PR TITLE
[BUG] app crashes when attempting to play a second video while another is playing

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "reinstall": "yarn purge-modules && yarn",
+    "purge-modules":"rm -rf node_modules",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
@@ -17,512 +17,512 @@ import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.jwplayer.pub.api.JWPlayer;
 import com.jwplayer.pub.api.PlayerState;
-import com.jwplayer.pub.api.media.adaptive.QualityLevel;
 import com.jwplayer.pub.api.configuration.PlayerConfig;
+import com.jwplayer.pub.api.media.adaptive.QualityLevel;
 import com.jwplayer.pub.api.media.audio.AudioTrack;
 
 import java.util.List;
 
 public class RNJWPlayerModule extends ReactContextBaseJavaModule {
 
-  private final ReactApplicationContext mReactContext;
+    private final ReactApplicationContext mReactContext;
 
-  private static final String TAG = "RNJWPlayerModule";
+    private static final String TAG = "RNJWPlayerModule";
 
-  public RNJWPlayerModule(ReactApplicationContext reactContext) {
-    super(reactContext);
+    public RNJWPlayerModule(ReactApplicationContext reactContext) {
+        super(reactContext);
 
-    mReactContext = reactContext;
-  }
+        mReactContext = reactContext;
+    }
 
-  @Override
-  public String getName() {
-    return TAG;
-  }
+    @Override
+    public String getName() {
+        return TAG;
+    }
 
-  @ReactMethod
-  public void loadPlaylist(final int reactTag, final ReadableArray playlistItems) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void loadPlaylist(final int reactTag, final ReadableArray playlistItems) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            JWPlayer player = playerView.mPlayerView.getPlayer();
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        JWPlayer player = playerView.mPlayerView.getPlayer();
 
-            PlayerConfig oldConfig = player.getConfig();
-            PlayerConfig config = new PlayerConfig.Builder()
-                    .autostart(oldConfig.getAutostart())
-                    .nextUpOffset(oldConfig.getNextUpOffset())
-                    .repeat(oldConfig.getRepeat())
-                    .relatedConfig(oldConfig.getRelatedConfig())
-                    .displayDescription(oldConfig.getDisplayDescription())
-                    .displayTitle(oldConfig.getDisplayTitle())
-                    .advertisingConfig(oldConfig.getAdvertisingConfig())
-                    .stretching(oldConfig.getStretching())
-                    .uiConfig(oldConfig.getUiConfig())
-                    .playlist(Util.createPlaylist(playlistItems))
-                    .allowCrossProtocolRedirects(oldConfig.getAllowCrossProtocolRedirects())
-                    .preload(oldConfig.getPreload())
-                    .useTextureView(oldConfig.useTextureView())
-                    .thumbnailPreview(oldConfig.getThumbnailPreview())
-                    .mute(oldConfig.getMute())
-                    .build();
+                        PlayerConfig oldConfig = player.getConfig();
+                        PlayerConfig config = new PlayerConfig.Builder()
+                                .autostart(oldConfig.getAutostart())
+                                .nextUpOffset(oldConfig.getNextUpOffset())
+                                .repeat(oldConfig.getRepeat())
+                                .relatedConfig(oldConfig.getRelatedConfig())
+                                .displayDescription(oldConfig.getDisplayDescription())
+                                .displayTitle(oldConfig.getDisplayTitle())
+                                .advertisingConfig(oldConfig.getAdvertisingConfig())
+                                .stretching(oldConfig.getStretching())
+                                .uiConfig(oldConfig.getUiConfig())
+                                .playlist(Util.createPlaylist(playlistItems))
+                                .allowCrossProtocolRedirects(oldConfig.getAllowCrossProtocolRedirects())
+                                .preload(oldConfig.getPreload())
+                                .useTextureView(oldConfig.useTextureView())
+                                .thumbnailPreview(oldConfig.getThumbnailPreview())
+                                .mute(oldConfig.getMute())
+                                .build();
 
-            player.setup(config);
-          }
+                        player.setup(config);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void play(final int reactTag) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void play(final int reactTag) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().play();
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().play();
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void toggleSpeed(final int reactTag) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void toggleSpeed(final int reactTag) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            double rate = playerView.mPlayerView.getPlayer().getPlaybackRate();
-            if (rate < 2) {
-              playerView.mPlayerView.getPlayer().setPlaybackRate(rate += 0.5);
-            } else {
-              playerView.mPlayerView.getPlayer().setPlaybackRate((float) 0.5);
-            }
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        double rate = playerView.mPlayerView.getPlayer().getPlaybackRate();
+                        if (rate < 2) {
+                            playerView.mPlayerView.getPlayer().setPlaybackRate(rate += 0.5);
+                        } else {
+                            playerView.mPlayerView.getPlayer().setPlaybackRate((float) 0.5);
+                        }
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void togglePIP(final int reactTag) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void togglePIP(final int reactTag) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            if (playerView.mPlayerView.getPlayer().isInPictureInPictureMode()) {
-              playerView.mPlayerView.getPlayer().exitPictureInPictureMode();
-            } else {
-              playerView.mPlayerView.getPlayer().enterPictureInPictureMode();
-            }
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        if (playerView.mPlayerView.getPlayer().isInPictureInPictureMode()) {
+                            playerView.mPlayerView.getPlayer().exitPictureInPictureMode();
+                        } else {
+                            playerView.mPlayerView.getPlayer().enterPictureInPictureMode();
+                        }
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setSpeed(final int reactTag, final float speed) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setSpeed(final int reactTag, final float speed) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().setPlaybackRate(speed);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().setPlaybackRate(speed);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
 
-  @ReactMethod
-  public void getCurrentQuality(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void getCurrentQuality(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            int quality = playerView.mPlayerView.getPlayer().getCurrentQuality();
-            promise.resolve(quality);
-          } else {
-            promise.reject("RNJW Error", "getCurrentQuality() Player is null");
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        int quality = playerView.mPlayerView.getPlayer().getCurrentQuality();
+                        promise.resolve(quality);
+                    } else {
+                        promise.reject("RNJW Error", "getCurrentQuality() Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setCurrentQuality(final int reactTag, final int index) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setCurrentQuality(final int reactTag, final int index) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().setCurrentQuality(index);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().setCurrentQuality(index);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
 
-  @ReactMethod
-  public void getQualityLevels(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void getQualityLevels(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            List<QualityLevel> qualityLevelsList = playerView.mPlayerView.getPlayer().getQualityLevels();
-            if (qualityLevelsList == null) { //if qualitylevels are null than pass empty array.
-              promise.resolve(null);
-              return;
-            }
-            WritableArray qualityLevels = Arguments.createArray();
-            for (int i = 0; i < qualityLevelsList.size(); i++) {
-              WritableMap qualityLevel = Arguments.createMap();
-              QualityLevel level = qualityLevelsList.get(i);
-              qualityLevel.putInt("playListPosition", level.getPlaylistPosition());
-              qualityLevel.putInt("bitRate", level.getBitrate());
-              qualityLevel.putString("label", level.getLabel());
-              qualityLevel.putInt("height", level.getHeight());
-              qualityLevel.putInt("width", level.getWidth());
-              qualityLevel.putInt("index", level.getTrackIndex());
-              qualityLevels.pushMap(qualityLevel);
-            }
-            promise.resolve(qualityLevels);
-          } else {
-            promise.reject("RNJW Error", "getQualityLevels() Player is null");
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        List<QualityLevel> qualityLevelsList = playerView.mPlayerView.getPlayer().getQualityLevels();
+                        if (qualityLevelsList == null) { //if qualitylevels are null than pass empty array.
+                            promise.resolve(null);
+                            return;
+                        }
+                        WritableArray qualityLevels = Arguments.createArray();
+                        for (int i = 0; i < qualityLevelsList.size(); i++) {
+                            WritableMap qualityLevel = Arguments.createMap();
+                            QualityLevel level = qualityLevelsList.get(i);
+                            qualityLevel.putInt("playListPosition", level.getPlaylistPosition());
+                            qualityLevel.putInt("bitRate", level.getBitrate());
+                            qualityLevel.putString("label", level.getLabel());
+                            qualityLevel.putInt("height", level.getHeight());
+                            qualityLevel.putInt("width", level.getWidth());
+                            qualityLevel.putInt("index", level.getTrackIndex());
+                            qualityLevels.pushMap(qualityLevel);
+                        }
+                        promise.resolve(qualityLevels);
+                    } else {
+                        promise.reject("RNJW Error", "getQualityLevels() Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void pause(final int reactTag) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void pause(final int reactTag) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            if(!playerView.getIsCastActive()){
-              playerView.mPlayerView.getPlayer().pause();
-              playerView.userPaused = true;
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        if (!playerView.getIsCastActive()) {
+                            playerView.mPlayerView.getPlayer().pause();
+                            playerView.userPaused = true;
 
-            }
-          }
+                        }
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void stop(final int reactTag) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void stop(final int reactTag) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            if(!playerView.getIsCastActive()){
-              playerView.mPlayerView.getPlayer().stop();
-              playerView.userPaused = true;
-            }
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        if (!playerView.getIsCastActive()) {
+                            playerView.mPlayerView.getPlayer().stop();
+                            playerView.userPaused = true;
+                        }
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void seekTo(final int reactTag, final double time) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void seekTo(final int reactTag, final double time) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().seek(time);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().seek(time);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setPlaylistIndex(final int reactTag, final int index) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setPlaylistIndex(final int reactTag, final int index) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().playlistItem(index);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().playlistItem(index);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setControls(final int reactTag, final boolean show) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setControls(final int reactTag, final boolean show) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().setControls(show);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().setControls(show);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void position(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void position(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            promise.resolve((Double.valueOf(playerView.mPlayerView.getPlayer().getPosition()).intValue()));
-          } else {
-            promise.reject("RNJW Error", "Player is null");
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        promise.resolve((Double.valueOf(playerView.mPlayerView.getPlayer().getPosition()).intValue()));
+                    } else {
+                        promise.reject("RNJW Error", "Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            promise.reject("RNJW Error", e);
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      promise.reject("RNJW Error", e);
     }
-  }
 
-  @ReactMethod
-  public void state(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void state(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            PlayerState playerState = playerView.mPlayerView.getPlayer().getState();
-            promise.resolve(stateToInt(playerState));
-          } else {
-            promise.reject("RNJW Error", "Player is null");
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        PlayerState playerState = playerView.mPlayerView.getPlayer().getState();
+                        promise.resolve(stateToInt(playerState));
+                    } else {
+                        promise.reject("RNJW Error", "Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            promise.reject("RNJW Error", e);
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      promise.reject("RNJW Error", e);
     }
-  }
 
-  @ReactMethod
-  public void setFullscreen(final int reactTag, final boolean fullscreen) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setFullscreen(final int reactTag, final boolean fullscreen) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().setFullscreen(fullscreen, fullscreen);
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        playerView.mPlayerView.getPlayer().setFullscreen(fullscreen, fullscreen);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setVolume(final int reactTag, final int volume) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setVolume(final int reactTag, final int volume) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayerView != null) {
-            int maxValue = playerView.audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-            if (volume <= maxValue) {
-              playerView.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, volume, 0);
-            } else {
-              playerView.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxValue, 0);
-            }
-          }
+                    if (playerView != null && playerView.mPlayerView != null) {
+                        int maxValue = playerView.audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+                        if (volume <= maxValue) {
+                            playerView.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, volume, 0);
+                        } else {
+                            playerView.audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, maxValue, 0);
+                        }
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void getAudioTracks(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void getAudioTracks(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayer != null) {
-            List<AudioTrack> audioTrackList = playerView.mPlayer.getAudioTracks();
-            WritableArray audioTracks = Arguments.createArray();
-            if (audioTrackList != null) {
-              for (int i = 0; i < audioTrackList.size(); i++) {
-                WritableMap audioTrack = Arguments.createMap();
-                AudioTrack track = audioTrackList.get(i);
-                audioTrack.putString("name", track.getName());
-                audioTrack.putString("language", track.getLanguage());
-                audioTrack.putString("groupId", track.getGroupId());
-                audioTrack.putBoolean("defaultTrack", track.isDefaultTrack());
-                audioTrack.putBoolean("autoSelect", track.isAutoSelect());
-                audioTracks.pushMap(audioTrack);
-              }
-            }
-            promise.resolve(audioTracks);
-          } else {
-            promise.reject("RNJW Error", "Player is null");
-          }
+                    if (playerView != null && playerView.mPlayer != null) {
+                        List<AudioTrack> audioTrackList = playerView.mPlayer.getAudioTracks();
+                        WritableArray audioTracks = Arguments.createArray();
+                        if (audioTrackList != null) {
+                            for (int i = 0; i < audioTrackList.size(); i++) {
+                                WritableMap audioTrack = Arguments.createMap();
+                                AudioTrack track = audioTrackList.get(i);
+                                audioTrack.putString("name", track.getName());
+                                audioTrack.putString("language", track.getLanguage());
+                                audioTrack.putString("groupId", track.getGroupId());
+                                audioTrack.putBoolean("defaultTrack", track.isDefaultTrack());
+                                audioTrack.putBoolean("autoSelect", track.isAutoSelect());
+                                audioTracks.pushMap(audioTrack);
+                            }
+                        }
+                        promise.resolve(audioTracks);
+                    } else {
+                        promise.reject("RNJW Error", "Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            promise.reject("RNJW Error", e);
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      promise.reject("RNJW Error", e);
     }
-  }
 
-  @ReactMethod
-  public void getCurrentAudioTrack(final int reactTag, final Promise promise) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void getCurrentAudioTrack(final int reactTag, final Promise promise) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayer != null) {
-            promise.resolve(playerView.mPlayer.getCurrentAudioTrack());
-          } else {
-            promise.reject("RNJW Error", "Player is null");
-          }
+                    if (playerView != null && playerView.mPlayer != null) {
+                        promise.resolve(playerView.mPlayer.getCurrentAudioTrack());
+                    } else {
+                        promise.reject("RNJW Error", "Player is null");
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            promise.reject("RNJW Error", e);
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      promise.reject("RNJW Error", e);
     }
-  }
 
-  @ReactMethod
-  public void setCurrentAudioTrack(final int reactTag, final int index) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setCurrentAudioTrack(final int reactTag, final int index) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayer != null) {
-            playerView.mPlayer.setCurrentAudioTrack(index);
-          }
+                    if (playerView != null && playerView.mPlayer != null) {
+                        playerView.mPlayer.setCurrentAudioTrack(index);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  @ReactMethod
-  public void setCurrentCaptions(final int reactTag, final int index) {
-    try {
-      UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
-      uiManager.addUIBlock(new UIBlock() {
-        public void execute (NativeViewHierarchyManager nvhm) {
-          RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
+    @ReactMethod
+    public void setCurrentCaptions(final int reactTag, final int index) {
+        try {
+            UIManagerModule uiManager = mReactContext.getNativeModule(UIManagerModule.class);
+            uiManager.addUIBlock(new UIBlock() {
+                public void execute(NativeViewHierarchyManager nvhm) {
+                    RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
-          if (playerView != null && playerView.mPlayer != null) {
-            playerView.mPlayer.setCurrentCaptions(index);
-          }
+                    if (playerView != null && playerView.mPlayer != null) {
+                        playerView.mPlayer.setCurrentCaptions(index);
+                    }
+                }
+            });
+        } catch (IllegalViewOperationException e) {
+            throw e;
         }
-      });
-    } catch (IllegalViewOperationException e) {
-      throw e;
     }
-  }
 
-  private int stateToInt(PlayerState playerState) {
-    switch (playerState) {
-      case IDLE:
-        return 0;
-      case BUFFERING:
-        return 1;
-      case PLAYING:
-        return 2;
-      case PAUSED:
-        return 3;
-      case COMPLETE:
-        return 4;
-      case ERROR:
-        return 5;
-      default:
-        return -1;
+    private int stateToInt(PlayerState playerState) {
+        switch (playerState) {
+            case IDLE:
+                return 0;
+            case BUFFERING:
+                return 1;
+            case PLAYING:
+                return 2;
+            case PAUSED:
+                return 3;
+            case COMPLETE:
+                return 4;
+            case ERROR:
+                return 5;
+            default:
+                return -1;
+        }
     }
-  }
 }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.IllegalViewOperationException;
@@ -21,9 +20,7 @@ import com.jwplayer.pub.api.PlayerState;
 import com.jwplayer.pub.api.media.adaptive.QualityLevel;
 import com.jwplayer.pub.api.configuration.PlayerConfig;
 import com.jwplayer.pub.api.media.audio.AudioTrack;
-import com.jwplayer.pub.api.media.playlists.PlaylistItem;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RNJWPlayerModule extends ReactContextBaseJavaModule {
@@ -250,8 +247,11 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
           RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
           if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().pause();
-            playerView.userPaused = true;
+            if(!playerView.getIsCastActive()){
+              playerView.mPlayerView.getPlayer().pause();
+              playerView.userPaused = true;
+
+            }
           }
         }
       });
@@ -269,8 +269,10 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
           RNJWPlayerView playerView = (RNJWPlayerView) nvhm.resolveView(reactTag);
 
           if (playerView != null && playerView.mPlayerView != null) {
-            playerView.mPlayerView.getPlayer().stop();
-            playerView.userPaused = true;
+            if(!playerView.getIsCastActive()){
+              playerView.mPlayerView.getPlayer().stop();
+              playerView.userPaused = true;
+            }
           }
         }
       });


### PR DESCRIPTION
### What does this Pull Request do?
- Adds check if background service is running before attempting to bind it to activity
- Adds warning message in Android for when above happens
- Adds comments explaining why not to do this

### Why is this Pull Request needed?
- Fatal crash thrown when developer has two players with background audio enabled (this is not a valid use case in the current configuration)

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no 

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/77)
