### PR TITLE
[BUG] Error and warning standardization

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1015,7 +1015,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         // Legacy
         // This isn't the ideal way to do this on Android. All drawables/colors/themes shoudld
         // be targed using styling. See `https://docs.jwplayer.com/players/docs/android-styling-guide`
-        // for more information on how best to override the JWP styles using XML. If you are unsure of a 
+        // for more information on how best to override the JWP styles using XML. If you are unsure of a
         // color/drawable/theme, open an `Ask` issue.
         if (mColors != null) {
             if (mColors.hasKey("backgroundColor")) {
@@ -1331,7 +1331,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putString("message", "onPlayerAdWarning");
         event.putInt("code", adWarningEvent.getCode());
         event.putInt("adErrorCode", adWarningEvent.getAdErrorCode());
-        event.putString("error", adWarningEvent.getMessage());
+        event.putString("warning", adWarningEvent.getMessage());
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerAdWarning", event);
     }
 
@@ -1485,6 +1485,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         if (ex != null) {
             event.putString("error", ex.toString());
             event.putString("description", errorEvent.getMessage());
+            event.putInt("errorCode", errorEvent.getErrorCode());
         }
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerError", event);
 
@@ -1635,6 +1636,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onSetupError(SetupErrorEvent setupErrorEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onSetupError");
+        event.putString("errorMessage", setupErrorEvent.getMessage());
+        event.putInt("errorCode", setupErrorEvent.getCode());
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topSetupPlayerError", event);
 
         updateWakeLock(false);

--- a/index.d.ts
+++ b/index.d.ts
@@ -483,6 +483,15 @@ declare module "@jwplayer/jwplayer-react-native" {
     rate: number;
     at: number;
   }
+  interface PlayerSetupErrorProps {
+    errorMessage?: string;
+    errorCode?: number;
+  }
+  interface PlayerErrorProps {
+    error?: string;
+    errorCode?: number;
+    description?: string; // Android Only
+  }
   interface TimeEventProps {
     position: number;
     duration: number;
@@ -504,15 +513,17 @@ declare module "@jwplayer/jwplayer-react-native" {
     error: string;
   }
   interface PlayerWarningEventProps {
-    code: string;
-    warning: string;
+    code?: number;
+    warning?: string;
+    adErrorCode?: number; // Android only
   }
   interface AdEventProps {
     client?: string;
     reason?: string;
     type: number;
   }
-  type NativeError = (event: BaseEvent<PlayerErrorEventProps>) => void;
+  // Overloaded type to be used in multiple error events
+  type NativeError = (event: BaseEvent<PlayerErrorEventProps> | BaseEvent<PlayerSetupErrorProps> | BaseEvent<PlayerErrorProps>) => void;
   type NativeWarning = (event: BaseEvent<PlayerWarningEventProps>) => void;
   interface PropsType {
     config: Config | JwConfig;
@@ -532,9 +543,9 @@ declare module "@jwplayer/jwplayer-react-native" {
     onRateChanged?: (event?: BaseEvent<RateChangedEventProps>) => void;
     onSetupPlayerError?: NativeError;
     onPlayerError?: NativeError;
-    onPlayerWarning?: NativeWarning;
-    onPlayerAdError?: NativeError;
-    onPlayerAdWarning?: NativeWarning;
+    onPlayerWarning?: NativeWarning; 
+    onPlayerAdError?: NativeError; 
+    onPlayerAdWarning?: NativeWarning; 
     onAdEvent?: (event: BaseEvent<AdEventProps>) => void;
     onAdTime?: (event: BaseEvent<TimeEventProps>) => void;
     onBuffer?: () => void;

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -960,12 +960,12 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
     }
 
     func jwplayer(_ player:JWPlayer, failedWithError code:UInt, message:String) {
-        self.onPlayerError?(["error": message])
+        self.onPlayerError?(["error": message, "errorCode": code])
         playerFailed = true
     }
 
     func jwplayer(_ player:JWPlayer, failedWithSetupError code:UInt, message:String) {
-        self.onSetupPlayerError?(["error": message])
+        self.onSetupPlayerError?(["errorMessage": message, "errorCode": code])
         playerFailed = true
     }
 
@@ -979,7 +979,7 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
 
 
     func jwplayer(_ player:JWPlayer, encounteredAdWarning code:UInt, message:String) {
-        self.onPlayerAdWarning?(["warning": message])
+        self.onPlayerAdWarning?(["warning": message, "code": code])
     }
 
 

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -55,13 +55,13 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
 
     override func jwplayer(_ player:JWPlayer, failedWithError code:UInt, message:String) {
         super.jwplayer(player, failedWithError:code, message:message)
-        parentView?.onPlayerError?(["error": message])
+        parentView?.onPlayerError?(["error": message, "errorCode": code])
         parentView?.playerFailed = true
     }
 
     override func jwplayer(_ player:JWPlayer, failedWithSetupError code:UInt, message:String) {
         super.jwplayer(player, failedWithSetupError:code, message:message)
-        parentView?.onSetupPlayerError?(["error": message])
+        parentView?.onSetupPlayerError?(["errorMessage": message, "errorCode": code])
         parentView?.playerFailed = true
     }
 
@@ -78,7 +78,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
 
     override func jwplayer(_ player:JWPlayer, encounteredAdWarning code:UInt, message:String) {
         super.jwplayer(player, encounteredAdWarning:code, message:message)
-        parentView?.onPlayerAdWarning?(["warning": message])
+        parentView?.onPlayerAdWarning?(["warning": message, "code": code])
     }
 
 


### PR DESCRIPTION
### What does this Pull Request do?
- Ensure warning and errors are the same for both platforms
- Ensure native events are passed to react side

### Why is this Pull Request needed?
- Errors weren't being surfaced (sometimes)
- Info in warnings and errors was missing information

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/63)
