### PR TITLE
[bug]Updates ios setCurrentCaptions to implement correctly

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -412,10 +412,14 @@ class RNJWPlayerViewManager: RCTViewManager {
                 return
             }
 
-            if let playerView = view.playerView {
-                playerView.player.currentCaptionsTrack = index.intValue + 1
-            } else if let playerViewController = view.playerViewController {
-                playerViewController.player.currentCaptionsTrack = index.intValue + 1
+            do {
+                if let playerView = view.playerView {
+                    try playerView.player.setCaptionTrack(index: index.intValue)
+                } else if let playerViewController = view.playerViewController {
+                    try playerViewController.player.setCaptionTrack(index: index.intValue)
+                }
+            } catch {
+                print("Error setting caption track: \(error)")
             }
         }
     }


### PR DESCRIPTION
### What does this Pull Request do?

Switches setCurrentCaptions to use setCaptionTrack(index:) instead of currentCaptionsTrack = index. This is what JWPlayer’s docs say to use. https://sdk.jwplayer.com/ios/v4/reference/Protocols/JWPlayerProtocol.html#/c:@M@JWPlayerKit@objc(pl)JWPlayerProtocol(im)setCaptionTrackWithIndex:error:

### Why is this Pull Request needed?

The old way didn’t match their official docs, so this should be more correct and less likely to break.

### Anything to double-check?

Make sure try is used right for the setCaptionTrack method, since it can throw errors.

### Any related PRs?

Nope.
