### PR TITLE
[BUG] Take the quite call out of player constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,8 +381,7 @@ export default class JWPlayer extends Component {
 
 		this._playerId = playerId++;
 		this.ref_key = `${RCT_RNJWPLAYER_REF}-${this._playerId}`;
-
-		this.quite();
+	
 	}
 
 	shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
### What does this Pull Request do?
- Stop calling `.quite` when building a new player

### Why is this Pull Request needed?
- Adding a new player can disrupt playback for already attached players

### Are there any points in the code the reviewer needs to double check?
- Consider the issue on iOS when players are destroyed individually and what can happen to the audio session.

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/71)
