### PR TITLE
[BUG] onAudioTracks and getAudioTracks not working

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -470,6 +470,8 @@ public class RNJWPlayerView extends RelativeLayout implements
                     EventType.SETUP_ERROR,
                     EventType.BUFFER,
                     EventType.TIME,
+                    EventType.AUDIO_TRACKS,
+                    EventType.AUDIO_TRACK_CHANGED,
                     EventType.PLAYLIST,
                     EventType.PLAYLIST_ITEM,
                     EventType.PLAYLIST_COMPLETE,

--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -306,24 +306,22 @@ class RNJWPlayerViewManager: RCTViewManager {
                 return
             }
 
-            let audioTracks: [Any]? = view.playerView?.player.audioTracks ?? view.playerViewController?.player.audioTracks
-
-            if let audioTracks = audioTracks as? [[String: Any]] {
+            let audioTracks: [JWMediaSelectionOption]? = view.playerView?.player.audioTracks ?? view.playerViewController?.player.audioTracks
+        
+            // V4 tracks object instead of the V3 JSON object of old
+            if let audioTracks = audioTracks {
                 var results: [[String: Any]] = []
                 for track in audioTracks {
-                    if let language = track["language"], let autoSelect = track["autoselect"],
-                       let defaultTrack = track["defaulttrack"], let name = track["name"],
-                       let groupId = track["groupid"] {
+                    let track = track as JWMediaSelectionOption
                         let trackDict: [String: Any] = [
-                            "language": language,
-                            "autoSelect": autoSelect,
-                            "defaultTrack": defaultTrack,
-                            "name": name,
-                            "groupId": groupId
+                            "language": track.extendedLanguageTag ?? "UNKNOWN", // Intentionally defaulting to a non-spec language if none found
+//                            "autoSelect": autoSelect, // not available in V4
+                            "defaultTrack": track.defaultOption,
+                            "name": track.name
+//                            "groupId": groupId // not available in V4
                         ]
                         results.append(trackDict)
                     }
-                }
                 resolve(results)
             } else {
                 let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "There are no audio tracks"])


### PR DESCRIPTION
### What does this Pull Request do?
- Add missing listener for Android tracks callbacks
- Modernize getAudioTracks for iOS v4 objects

### Why is this Pull Request needed?
- Android onAudioTracks not firing
- getAudioTracks broken on iOS

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/65)
