### PR TITLE
Added .description so onAdEvent returns a string

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1384,7 +1384,7 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
     // MARK: - JWPlayer Ad Delegate
 
     func jwplayer(_ player:JWPlayer, adEvent event:JWAdEvent) {
-        self.onAdEvent?(["client": event.client, "type": event.type])
+        self.onAdEvent?(["client": event.client.description, "type": event.type.description])
     }
 
     // MARK: - JWPlayer AV Delegate

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -486,7 +486,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
 
     override func jwplayer(_ player: JWPlayer, adEvent event: JWAdEvent) {
         super.jwplayer(player, adEvent:event)
-        parentView?.onAdEvent?(["client": event.client, "type": event.type])
+        parentView?.onAdEvent?(["client": event.client.description, "type": event.type.description])
     }
 
     // MARK: - JWPlayer Cast Delegate


### PR DESCRIPTION
### What does this Pull Request do?
This fixes the onAdEvent in the native iOS codebase. It does this by adding .description to the argument so that a string is passed to the RN wrapper. Example:

`onAdEvent?(["client": event.client.description, "type": event.type.description])`

### Why is this Pull Request needed?
When logging the onAdEvent on an iOS device the event was logging null for `client` and `type`. For example:

`onAdEvent {"client": null, "target": 187, "type": null}`

After the fix, the log now looks like this:

`onAdEvent {"client": "googima", "target": 187, "type": "request"}`

### Are there any points in the code the reviewer needs to double check?
No

### Are there any Pull Requests open in other repos which need to be merged with this?
No

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/###)
