### PR TITLE
Use number representation of ad event type and client.

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1314,7 +1314,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoaded(AdLoadedEvent adLoadedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adLoadedEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adLoadedEvent.getClient()));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1322,7 +1322,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoadedXml(AdLoadedXmlEvent adLoadedXmlEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adLoadedXmlEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adLoadedXmlEvent.getClient()));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1331,7 +1331,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
         event.putString("reason", adPauseEvent.getAdPauseReason().toString());
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypePause));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypePause));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1340,7 +1340,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
         event.putString("reason", adPlayEvent.getAdPlayReason().toString());
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypePlay));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypePlay));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1348,8 +1348,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakEnd(AdBreakEndEvent adBreakEndEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adBreakEndEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakEnd));
+        event.putInt("client", Util.getAdEventClientValue(adBreakEndEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakEnd));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1357,8 +1357,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakStart(AdBreakStartEvent adBreakStartEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adBreakStartEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakStart));
+        event.putInt("client", Util.getAdEventClientValue(adBreakStartEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakStart));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1366,7 +1366,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakIgnored(AdBreakIgnoredEvent adBreakIgnoredEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adBreakIgnoredEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adBreakIgnoredEvent.getClient()));
         // missing type code
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1375,8 +1375,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdClick(AdClickEvent adClickEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adClickEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeClicked));
+        event.putInt("client", Util.getAdEventClientValue(adClickEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeClicked));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1384,7 +1384,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdCompanions(AdCompanionsEvent adCompanionsEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeCompanion));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeCompanion));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1392,8 +1392,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdComplete(AdCompleteEvent adCompleteEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adCompleteEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeComplete));
+        event.putInt("client", Util.getAdEventClientValue(adCompleteEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeComplete));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1421,8 +1421,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdImpression(AdImpressionEvent adImpressionEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adImpressionEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeImpression));
+        event.putInt("client", Util.getAdEventClientValue(adImpressionEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeImpression));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1430,8 +1430,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdMeta(AdMetaEvent adMetaEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adMetaEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeMeta));
+        event.putInt("client", Util.getAdEventClientValue(adMetaEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeMeta));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1439,8 +1439,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdRequest(AdRequestEvent adRequestEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adRequestEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeRequest));
+        event.putInt("client", Util.getAdEventClientValue(adRequestEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeRequest));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1448,8 +1448,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSchedule(AdScheduleEvent adScheduleEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adScheduleEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeSchedule));
+        event.putInt("client", Util.getAdEventClientValue(adScheduleEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeSchedule));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1457,8 +1457,8 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSkipped(AdSkippedEvent adSkippedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getEventClientValue(adSkippedEvent.getClient()));
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeSkipped));
+        event.putInt("client", Util.getAdEventClientValue(adSkippedEvent.getClient()));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeSkipped));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1466,7 +1466,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdStarted(AdStartedEvent adStartedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeStarted));
+        event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeStarted));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1314,7 +1314,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoaded(AdLoadedEvent adLoadedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adLoadedEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adLoadedEvent.getClient()));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1322,7 +1322,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoadedXml(AdLoadedXmlEvent adLoadedXmlEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adLoadedXmlEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adLoadedXmlEvent.getClient()));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1348,7 +1348,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakEnd(AdBreakEndEvent adBreakEndEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adBreakEndEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adBreakEndEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakEnd));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1357,7 +1357,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakStart(AdBreakStartEvent adBreakStartEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adBreakStartEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adBreakStartEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakStart));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1366,7 +1366,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakIgnored(AdBreakIgnoredEvent adBreakIgnoredEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adBreakIgnoredEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adBreakIgnoredEvent.getClient()));
         // missing type code
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1375,7 +1375,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdClick(AdClickEvent adClickEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adClickEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adClickEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeClicked));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1392,7 +1392,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdComplete(AdCompleteEvent adCompleteEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adCompleteEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adCompleteEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeComplete));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1421,7 +1421,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdImpression(AdImpressionEvent adImpressionEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adImpressionEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adImpressionEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeImpression));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1430,7 +1430,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdMeta(AdMetaEvent adMetaEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adMetaEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adMetaEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeMeta));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1439,7 +1439,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdRequest(AdRequestEvent adRequestEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adRequestEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adRequestEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeRequest));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1448,7 +1448,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSchedule(AdScheduleEvent adScheduleEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adScheduleEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adScheduleEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeSchedule));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1457,7 +1457,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSkipped(AdSkippedEvent adSkippedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putString("client", adSkippedEvent.getClient().toString());
+        event.putInt("client", Util.getEventClientValue(adSkippedEvent.getClient()));
         event.putInt("type", Util.getEventTypeValue(Util.AdEventType.JWAdEventTypeSkipped));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1407,7 +1407,6 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putInt("code", adErrorEvent.getCode());
         event.putInt("adErrorCode", adErrorEvent.getAdErrorCode());
         event.putString("error", adErrorEvent.getMessage());
-        event.putInt("client", Util.getAdEventClientValue(adErrorEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerAdError", event);
     }
 
@@ -1418,7 +1417,6 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putInt("code", adWarningEvent.getCode());
         event.putInt("adErrorCode", adWarningEvent.getAdErrorCode());
         event.putString("warning", adWarningEvent.getMessage());
-        event.putInt("client", Util.getAdEventClientValue(adWarningEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerAdWarning", event);
     }
 

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1314,7 +1314,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoaded(AdLoadedEvent adLoadedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adLoadedEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adLoadedEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1322,7 +1322,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdLoadedXml(AdLoadedXmlEvent adLoadedXmlEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adLoadedXmlEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adLoadedXmlEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
 
@@ -1331,6 +1331,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
         event.putString("reason", adPauseEvent.getAdPauseReason().toString());
+        event.putInt("client", Util.getAdEventClientValue(adPauseEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypePause));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1340,6 +1341,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
         event.putString("reason", adPlayEvent.getAdPlayReason().toString());
+        event.putInt("client", Util.getAdEventClientValue(adPlayEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypePlay));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1348,7 +1350,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakEnd(AdBreakEndEvent adBreakEndEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adBreakEndEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adBreakEndEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakEnd));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1357,7 +1359,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakStart(AdBreakStartEvent adBreakStartEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adBreakStartEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adBreakStartEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeAdBreakStart));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1366,7 +1368,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdBreakIgnored(AdBreakIgnoredEvent adBreakIgnoredEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adBreakIgnoredEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adBreakIgnoredEvent));
         // missing type code
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1375,7 +1377,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdClick(AdClickEvent adClickEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adClickEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adClickEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeClicked));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1384,6 +1386,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdCompanions(AdCompanionsEvent adCompanionsEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
+        event.putInt("client", Util.getAdEventClientValue(adCompanionsEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeCompanion));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1392,7 +1395,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdComplete(AdCompleteEvent adCompleteEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adCompleteEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adCompleteEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeComplete));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1404,6 +1407,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putInt("code", adErrorEvent.getCode());
         event.putInt("adErrorCode", adErrorEvent.getAdErrorCode());
         event.putString("error", adErrorEvent.getMessage());
+        event.putInt("client", Util.getAdEventClientValue(adErrorEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerAdError", event);
     }
 
@@ -1414,6 +1418,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         event.putInt("code", adWarningEvent.getCode());
         event.putInt("adErrorCode", adWarningEvent.getAdErrorCode());
         event.putString("warning", adWarningEvent.getMessage());
+        event.putInt("client", Util.getAdEventClientValue(adWarningEvent));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlayerAdWarning", event);
     }
 
@@ -1421,7 +1426,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdImpression(AdImpressionEvent adImpressionEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adImpressionEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adImpressionEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeImpression));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1430,7 +1435,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdMeta(AdMetaEvent adMetaEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adMetaEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adMetaEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeMeta));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1439,7 +1444,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdRequest(AdRequestEvent adRequestEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adRequestEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adRequestEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeRequest));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1448,7 +1453,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSchedule(AdScheduleEvent adScheduleEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adScheduleEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adScheduleEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeSchedule));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1457,7 +1462,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdSkipped(AdSkippedEvent adSkippedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
-        event.putInt("client", Util.getAdEventClientValue(adSkippedEvent.getClient()));
+        event.putInt("client", Util.getAdEventClientValue(adSkippedEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeSkipped));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }
@@ -1466,6 +1471,7 @@ public class RNJWPlayerView extends RelativeLayout implements
     public void onAdStarted(AdStartedEvent adStartedEvent) {
         WritableMap event = Arguments.createMap();
         event.putString("message", "onAdEvent");
+        event.putInt("client", Util.getAdEventClientValue(adStartedEvent));
         event.putInt("type", Util.getAdEventTypeValue(Util.AdEventType.JWAdEventTypeStarted));
         getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topAdEvent", event);
     }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.jwplayer.pub.api.JsonHelper;
 import com.jwplayer.pub.api.media.ads.AdBreak;
+import com.jwplayer.pub.api.media.ads.AdClient;
 import com.jwplayer.pub.api.media.captions.Caption;
 import com.jwplayer.pub.api.media.captions.CaptionType;
 import com.jwplayer.pub.api.media.playlists.MediaSource;
@@ -255,5 +256,35 @@ public class Util {
     // Method to get the event type value
     public static int getEventTypeValue(AdEventType eventType) {
         return eventType.getValue();
+    }
+
+    public enum AdEventClient {
+        JWAdEventClientJWPlayer(0),
+        JWAdEventClientGoogleIMA(1),
+        JWAdEventClientGoogleIMADAI(2),
+        JWAdEventClientUnknown(3);
+
+        private final int value;
+
+        AdEventClient(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    public static int getEventClientValue(AdClient client) {
+        switch (client) {
+            case IMA:
+                return AdEventClient.JWAdEventClientGoogleIMA.getValue();
+            case IMA_DAI:
+                return AdEventClient.JWAdEventClientGoogleIMADAI.getValue();
+            case VAST:
+                return AdEventClient.JWAdEventClientJWPlayer.getValue();
+            default:
+                return AdEventClient.JWAdEventClientUnknown.getValue();
+        }
     }
 }

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -9,8 +9,9 @@ import android.webkit.URLUtil;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.jwplayer.pub.api.JsonHelper;
+import com.jwplayer.pub.api.configuration.ads.AdvertisingConfig;
+import com.jwplayer.pub.api.events.Event;
 import com.jwplayer.pub.api.media.ads.AdBreak;
-import com.jwplayer.pub.api.media.ads.AdClient;
 import com.jwplayer.pub.api.media.captions.Caption;
 import com.jwplayer.pub.api.media.captions.CaptionType;
 import com.jwplayer.pub.api.media.playlists.MediaSource;
@@ -275,8 +276,13 @@ public class Util {
         }
     }
 
-    public static int getAdEventClientValue(AdClient client) {
-        switch (client) {
+    public static int getAdEventClientValue(Event adEvent) {
+        AdvertisingConfig adConfig = adEvent.getPlayer().getConfig().getAdvertisingConfig();
+        if (adConfig == null) {
+            return AdEventClient.JWAdEventClientUnknown.getValue();
+        }
+
+        switch (adConfig.getAdClient()) {
             case IMA:
                 return AdEventClient.JWAdEventClientGoogleIMA.getValue();
             case IMA_DAI:

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -254,7 +254,7 @@ public class Util {
     }
 
     // Method to get the event type value
-    public static int getEventTypeValue(AdEventType eventType) {
+    public static int getAdEventTypeValue(AdEventType eventType) {
         return eventType.getValue();
     }
 
@@ -275,7 +275,7 @@ public class Util {
         }
     }
 
-    public static int getEventClientValue(AdClient client) {
+    public static int getAdEventClientValue(AdClient client) {
         switch (client) {
             case IMA:
                 return AdEventClient.JWAdEventClientGoogleIMA.getValue();

--- a/index.d.ts
+++ b/index.d.ts
@@ -518,7 +518,7 @@ declare module "@jwplayer/jwplayer-react-native" {
     adErrorCode?: number; // Android only
   }
   interface AdEventProps {
-    client?: number;
+    client: number;
     reason?: string;
     type: number;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -518,7 +518,7 @@ declare module "@jwplayer/jwplayer-react-native" {
     adErrorCode?: number; // Android only
   }
   interface AdEventProps {
-    client?: string;
+    client?: number;
     reason?: string;
     type: number;
   }

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1384,7 +1384,7 @@ class RNJWPlayerView : UIView, JWPlayerDelegate, JWPlayerStateDelegate, JWAdDele
     // MARK: - JWPlayer Ad Delegate
 
     func jwplayer(_ player:JWPlayer, adEvent event:JWAdEvent) {
-        self.onAdEvent?(["client": event.client.description, "type": event.type.description])
+        self.onAdEvent?(["client": event.client.rawValue, "type": event.type.rawValue])
     }
 
     // MARK: - JWPlayer AV Delegate

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -486,7 +486,7 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerD
 
     override func jwplayer(_ player: JWPlayer, adEvent event: JWAdEvent) {
         super.jwplayer(player, adEvent:event)
-        parentView?.onAdEvent?(["client": event.client.description, "type": event.type.description])
+        parentView?.onAdEvent?(["client": event.client.rawValue, "type": event.type.rawValue])
     }
 
     // MARK: - JWPlayer Cast Delegate


### PR DESCRIPTION
### What does this Pull Request do?
PR updates the JS side `onAdEvent` callback by instead using and passing the number representation of ad client and ad event/type from the native side on both platforms ( IOS/Android ) . 

### Why is this Pull Request needed?
With this PR, we can be able to consistently derive on both platforms the ad client and event type using these available constants on the JS side:

1. Ad Event Types - https://github.com/jwplayer/jwplayer-react-native/blob/master/index.js#L40
2. Ad Clients - https://github.com/jwplayer/jwplayer-react-native/blob/master/index.js#L72

Example: 
```javascript
onAdEvent={({ nativeEvent }) => {
    const { JWAdEventTypeComplete, JWAdEventTypeImpression, JWAdEventTypePlay } = JWPlayerAdEvents;
    
    const isAdImpression = nativeEvent.type === JWAdEventTypeImpression;
    const isAdPlaying = nativeEvent.type === JWAdEventTypePlay;
    const isAdComplete = nativeEvent.type === JWAdEventTypeComplete;

    
    const [name] = Object.entries(JWPlayerAdClients).find(([name, client]) => client === nativeEvent.client);
    console.log(`ad client: ${name}`);
    

    if (isAdImpression) {
        // do something when ad impression occurs
        console.log('ad impression occurs');
    }

    if (isAdPlaying) {
        // do something when ad plays ( ex. submit for tracking that ad is playing )
        console.log('ad playing');
    }

    if (isAdComplete) {
        // do something when ad completes ( ex. set state to broadcast ad is completed )
        console.log('ad is complete');
    }
}}
```


### Are there any points in the code the reviewer needs to double check?
No.

### Are there any Pull Requests open in other repos which need to be merged with this?
No.


#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/124)
