### PR TITLE
[Android] Sync lifecycle of view with player

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -1092,7 +1092,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         addView(mPlayerView);
 
         // Ensure we have a valid state before applying to the player
-        registry.setCurrentState(Lifecycle.State.STARTED);
+        registry.setCurrentState(registry.getCurrentState()); // This is a hack to ensure player and view know the lifecycle state
 
         mPlayer = mPlayerView.getPlayer(this);
 


### PR DESCRIPTION
### What does this Pull Request do?
- Ensure player and player view are aware of current lifecycle state

### Why is this Pull Request needed?
- Ads were not playing due to lifecycle bing out of sync with actual state

### Are there any points in the code the reviewer needs to double check?
- No
- Using `backgroundAudioEnabled` was a workaround but not a viable long-term solution. 

### Are there any Pull Requests open in other repos which need to be merged with this?
- No

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/117)
