### PR TITLE
Fix loadPlaylist and fully expose loadPlaylistWithUrl

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -591,7 +591,16 @@ declare module "@jwplayer/jwplayer-react-native" {
     setControls(show: boolean): void;
     setLockScreenControls(show: boolean): void;
     seekTo(time: number): void;
-    loadPlaylist(playlistItems: PlaylistItem[] | JwPlaylistItem[] | string): void;
+    /**
+     * Side load playlist items into an already setup player
+     * @param playlistItems `PlaylistItem` or `JwPlaylistItem`
+     */
+    loadPlaylist(playlistItems: PlaylistItem[] | JwPlaylistItem[]): void;
+    /**
+     * Side load playlist via URL into an already setup player
+     * @param playlistUrl URL for playlist to load (format for response: json)
+     */
+    loadPlaylistWithUrl(playlistUrl: string): void;
     setFullscreen(fullScreen: boolean): void;
     position(): Promise<number>;
     setUpCastController(): void;

--- a/index.js
+++ b/index.js
@@ -535,6 +535,11 @@ export default class JWPlayer extends Component {
 			RNJWPlayerManager.loadPlaylist(this.getRNJWPlayerBridgeHandle(), playlistItems);
 	}
 
+	loadPlaylistWithUrl(playlistUrl) {
+		if (RNJWPlayerManager)
+			RNJWPlayerManager.loadPlaylistWithUrl(this.getRNJWPlayerBridgeHandle(), playlistUrl);
+	}
+
 	setFullscreen(fullscreen) {
 		if (RNJWPlayerManager)
 			RNJWPlayerManager.setFullscreen(

--- a/ios/RNJWPlayer/RNJWPlayerViewManager.m
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.m
@@ -136,7 +136,7 @@ RCT_EXTERN_METHOD(reset)
 
 RCT_EXTERN_METHOD(loadPlaylist: (nonnull NSNumber *)reactTag: (nonnull NSArray *)playlist)
 
-RCT_EXTERN_METHOD(loadPlaylist: (nonnull NSNumber *)reactTag: (nonnull NSString *)playlist)
+RCT_EXTERN_METHOD(loadPlaylistWithUrl: (nonnull NSNumber *)reactTag: (nonnull NSString *)playlist)
 
 RCT_EXTERN_METHOD(setFullscreen: (nonnull NSNumber *)reactTag: (BOOL)fullscreen)
 

--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -548,7 +548,18 @@ class RNJWPlayerViewManager: RCTViewManager {
                 } else if let playerViewController = view.playerViewController {
                     playerViewController.player.loadPlaylist(items: playlistArray)
                 }
-            } else if let playlistString = playlist as? String, let url = URL(string: playlistString) {
+            }
+        }
+    }
+    
+    @objc func loadPlaylistWithUrl(_ reactTag: NSNumber, _ playlistString: String) {
+        DispatchQueue.main.async {
+            guard let view = self.getPlayerView(reactTag: reactTag) else {
+                print("Invalid view returned from registry, expecting RNJWPlayerView")
+                return
+            }
+                        
+            if let url = URL(string: playlistString) {
                 if let playerView = view.playerView {
                     playerView.player.loadPlaylist(url: url)
                 } else if let playerViewController = view.playerViewController {


### PR DESCRIPTION
### What does this Pull Request do?
- Fix loadPlaylist on iOS
- Expose loadPlaylistWithUrl in JS

### Why is this Pull Request needed?
- Possible fatal crash on older ReactNative
- Type mismatch non-fatal issue

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/115)
