### PR TITLE
Handle both mediaId and mediaid case variations in playlist items

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -653,10 +653,10 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
         }
 
         // Process other properties
-        if let mediaId = item["mediaId"] as? String {
-            itemBuilder.mediaId(mediaId)
+        if let mediaId = (item["mediaId"] as? String) ?? (item["mediaid"] as? String) {
+             itemBuilder.mediaId(mediaId)
         }
-        
+
         if let userInfo = item["userInfo"] as? Dictionary<String, Any> {
             itemBuilder.userInfo(userInfo)
         }


### PR DESCRIPTION
### What does this Pull Request do?

- Fixes iOS recommendation playback looping when using onBeforeNextPlaylistItem by preserving the playlist item identifier in the RN iOS bridge.
- Updates RNJWPlayerView.getPlayerItem(...) to accept both mediaid (lowercase, used by the SDK) and mediaId (camelCase, used by some RN apps) when constructing a JWPlayerItem.
- Ensures the identifier survives the JS callback round-trip so the iOS SDK can correctly mark items as played and advance through recommendations.

### Why is this Pull Request needed?

- On iOS, after the first recommended video, playback could loop the same item because the identifier (mediaid) was lost when reconstructing the item from JS, preventing the SDK from marking it as played.
- The iOS SDK’s related handler uses mediaid/file to track played vs unplayed items; without a stable ID, it reselects the same recommendation instead of advancing.
- Handling both mediaid and mediaId maintains compatibility with RN apps and aligns iOS behavior with Android, resolving the iOS-only loop bug without API changes.


### Are there any points in the code the reviewer needs to double check?

No


### Are there any Pull Requests open in other repos which need to be merged with this?

No


#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/166
