### PR TITLE
Update README with expo-build-properties usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Follow these steps to add the library to your Android project:
                url 'https://mvn.jwplayer.com/content/repositories/releases/'
            }
    ```
+Alternative to the above, so that you don't have to re-add it to android/build.grade every time you do a prebuild --clean with EXPO,
+ install expo-build-properties plugin:
+``npx expo install expo-build-properties```
+
+and then add to app.json
+```
+    "plugins": [
+      ... (your other plugins go here)
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "extraMavenRepos": [
+              {
+                "url": "https://mvn.jwplayer.com/content/repositories/releases/"
+              }
+            ]
+          }
+        }
+      ]
+    ],
+```
 
 For more details and guidance regarding configuration and requirements, see the [JWP Android SDK documentation](https://docs.jwplayer.com/players/docs/android-overview#requirements).
 


### PR DESCRIPTION
Alternative way of adding the needed repository to android build process when using EXPO