### PR TITLE
fix: ensure PLAYER_CONTROLS_CONTAINER displayed in UI config

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
@@ -13,17 +13,16 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.IllegalViewOperationException;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.jwplayer.pub.api.JWPlayer;
 import com.jwplayer.pub.api.PlayerState;
+import com.jwplayer.pub.api.UiGroup;
 import com.jwplayer.pub.api.configuration.PlayerConfig;
+import com.jwplayer.pub.api.configuration.UiConfig;
 import com.jwplayer.pub.api.media.adaptive.QualityLevel;
 import com.jwplayer.pub.api.media.audio.AudioTrack;
+
 import java.util.List;
 
 public class RNJWPlayerModule extends ReactContextBaseJavaModule {
@@ -58,6 +57,21 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
         }
     }
 
+    /**
+     * Creates a UiConfig that ensures PLAYER_CONTROLS_CONTAINER is always shown.
+     * If controls are not shown, the PLAYER_CONTROLS_CONTAINER UI Group is not displayed.
+     * This logic ensures that the PLAYER_CONTROLS_CONTAINER UI Group is displayed regardless if controls are shown or not.
+     * There is no way to recover controls if you do not show this UiGroup.
+     * But you are able to hide the controls still if it is shown.
+     */
+    private UiConfig createUiConfigWithControlsContainer(JWPlayer player, UiConfig originalUiConfig) {
+        if (!player.getControls()) {
+            return new UiConfig.Builder(originalUiConfig).show(UiGroup.PLAYER_CONTROLS_CONTAINER).build();
+        } else {
+            return originalUiConfig;
+        }
+    }
+
     @ReactMethod
     public void loadPlaylist(final int reactTag, final ReadableArray playlistItems) {
         new Handler(Looper.getMainLooper()).post(() -> {
@@ -66,6 +80,7 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
                 JWPlayer player = playerView.mPlayerView.getPlayer();
 
                 PlayerConfig oldConfig = player.getConfig();
+                UiConfig uiConfig = createUiConfigWithControlsContainer(player, oldConfig.getUiConfig());
                 PlayerConfig config = new PlayerConfig.Builder()
                         .autostart(oldConfig.getAutostart())
                         .nextUpOffset(oldConfig.getNextUpOffset())
@@ -75,7 +90,7 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
                         .displayTitle(oldConfig.getDisplayTitle())
                         .advertisingConfig(oldConfig.getAdvertisingConfig())
                         .stretching(oldConfig.getStretching())
-                        .uiConfig(oldConfig.getUiConfig())
+                        .uiConfig(uiConfig)
                         .playlist(Util.createPlaylist(playlistItems))
                         .allowCrossProtocolRedirects(oldConfig.getAllowCrossProtocolRedirects())
                         .preload(oldConfig.getPreload())
@@ -97,6 +112,7 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
                 JWPlayer player = playerView.mPlayerView.getPlayer();
 
                 PlayerConfig oldConfig = player.getConfig();
+                UiConfig uiConfig = createUiConfigWithControlsContainer(player, oldConfig.getUiConfig());
                 PlayerConfig config = new PlayerConfig.Builder()
                         .autostart(oldConfig.getAutostart())
                         .nextUpOffset(oldConfig.getNextUpOffset())
@@ -106,7 +122,7 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
                         .displayTitle(oldConfig.getDisplayTitle())
                         .advertisingConfig(oldConfig.getAdvertisingConfig())
                         .stretching(oldConfig.getStretching())
-                        .uiConfig(oldConfig.getUiConfig())
+                        .uiConfig(uiConfig)
                         .playlistUrl(playlistUrl)
                         .allowCrossProtocolRedirects(oldConfig.getAllowCrossProtocolRedirects())
                         .preload(oldConfig.getPreload())

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -879,11 +879,27 @@ public class RNJWPlayerView extends RelativeLayout implements
 
     }
 
+    /**
+     * Creates a UiConfig that ensures PLAYER_CONTROLS_CONTAINER is always shown.
+     * If controls are not shown, the PLAYER_CONTROLS_CONTAINER UI Group is not displayed.
+     * This logic ensures that the PLAYER_CONTROLS_CONTAINER UI Group is displayed regardless if controls are shown or not.
+     * There is no way to recover controls if you do not show this UiGroup.
+     * But you are able to hide the controls still if it is shown.
+     */
+    private UiConfig createUiConfigWithControlsContainer(JWPlayer player, UiConfig originalUiConfig) {
+        if (!player.getControls()) {
+            return new UiConfig.Builder(originalUiConfig).show(UiGroup.PLAYER_CONTROLS_CONTAINER).build();
+        } else {
+            return originalUiConfig;
+        }
+    }
+
     public void setConfig(ReadableMap prop) {
         if (mConfig == null || !mConfig.equals(prop)) {
             if (mConfig != null && isOnlyDiff(prop, "playlist") && mPlayer != null) { // still safe check, even with JW
                 // JSON change
                 PlayerConfig oldConfig = mPlayer.getConfig();
+                UiConfig uiConfig = createUiConfigWithControlsContainer(mPlayer, oldConfig.getUiConfig());
                 PlayerConfig config = new PlayerConfig.Builder()
                         .autostart(oldConfig.getAutostart())
                         .nextUpOffset(oldConfig.getNextUpOffset())
@@ -893,7 +909,7 @@ public class RNJWPlayerView extends RelativeLayout implements
                         .displayTitle(oldConfig.getDisplayTitle())
                         .advertisingConfig(oldConfig.getAdvertisingConfig())
                         .stretching(oldConfig.getStretching())
-                        .uiConfig(oldConfig.getUiConfig())
+                        .uiConfig(uiConfig)
                         .playlist(Util.createPlaylist(mPlaylistProp))
                         .allowCrossProtocolRedirects(oldConfig.getAllowCrossProtocolRedirects())
                         .preload(oldConfig.getPreload())


### PR DESCRIPTION
### What does this Pull Request do?
- Checks player state for controls before rebuilding UiConfig

### Why is this Pull Request needed?
- UiGroup for PLAYER_CONTROLS_CONTAINER can soft lock the player if it isn't enabled

### Are there any points in the code the reviewer needs to double check?
- no

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/170)
