### PR TITLE
Add check for in PiP before loading new content on iOS

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -275,9 +275,28 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
                     }
                 }
 
+                // Check if player is in PiP mode before loading new playlist
+                var isPipActive = false
+                var pipController: AVPictureInPictureController?
+                
+                if let playerView = playerView {
+                    pipController = playerView.pictureInPictureController
+                    isPipActive = pipController?.isPictureInPictureActive ?? false
+                } else if let playerViewController = playerViewController {
+                    pipController = playerViewController.playerView.pictureInPictureController
+                    isPipActive = pipController?.isPictureInPictureActive ?? false
+                }
+                
                 if let playerViewController = playerViewController {
-                    playerViewController.player.loadPlaylist(items: playlistArray)
+                    // We must treat PiP mode differently and setup as a new config
+                    // or else the player will become unresponsive
+                    if isPipActive {
+                        setNewConfig(config: config)
+                    } else {
+                        playerViewController.player.loadPlaylist(items: playlistArray)
+                    }
                 } else if let playerView = playerView {
+                    // If you use player only, consider doing a simpliar check for PiP as above
                     playerView.player.loadPlaylist(items: playlistArray)
                 } else {
                     setNewConfig(config: config)


### PR DESCRIPTION
### What does this Pull Request do?
- Add check for in PiP before loading new content on iOS

### Why is this Pull Request needed?
- Player can get stuck if attempting to load content into a PiP player
- Force loading a new config instead to avoid this

### Are there any points in the code the reviewer needs to double check?
- Is a new config safe?

### Are there any Pull Requests open in other repos which need to be merged with this?
- no

#### Addresses Issue(s):

[GitHub Issue](https://github.com/jwplayer/jwplayer-react-native/issues/165)
