### PR TITLE
fix: Crash when touching player controls during destruction

### DIFF
--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -1470,7 +1470,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jwplayer/jwplayer-react-native@../../jwplayer-react-native":
-  version "1.3.1"
+  version "1.3.2"
   dependencies:
     lodash.isequalwith "^4.4.0"
 

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
@@ -1,5 +1,7 @@
 package com.jwplayer.rnjwplayer;
 
+import android.util.Log;
+
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
@@ -43,7 +45,14 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
     if (view == null || view.mPlayerView == null) {
       return;
     }
-    view.mPlayerView.getPlayer().setControls(controls);
+    // Add null check for getPlayer() to prevent crashes
+    try {
+      if (view.mPlayerView.getPlayer() != null) {
+        view.mPlayerView.getPlayer().setControls(controls);
+      }
+    } catch (Exception e) {
+      Log.w(TAG, "Error setting controls: " + e.getMessage());
+    }
   }
 
   /**
@@ -58,8 +67,15 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
     if (view == null || view.mPlayerView == null) {
       return;
     }
-    view.mPlayerView.getPlayer().stop();
-    view.setConfig(config);
+    // Add null check for getPlayer() to prevent crashes
+    try {
+      if (view.mPlayerView.getPlayer() != null) {
+        view.mPlayerView.getPlayer().stop();
+      }
+      view.setConfig(config);
+    } catch (Exception e) {
+      Log.w(TAG, "Error recreating player: " + e.getMessage());
+    }
   }
 
   public Map getExportedCustomBubblingEventTypeConstants() {


### PR DESCRIPTION
### What does this Pull Request do?

Fixes a race condition crash that occurs when player UI controls are touched during player destruction. The fix prevents touch events from reaching native SDK components that have already been torn down by:

1. Adding an `isDestroying` flag to prevent re-entry into `destroyPlayer()`
2. Immediately disabling all touch interactions on the player view before native SDK teardown begins
3. Adding defensive null checks in `RNJWPlayerViewManager` for `getPlayer()` calls

### Why is this Pull Request needed?

Users are experiencing crashes when navigating away from a player screen while interacting with controls (especially side seek or play/pause). The crash occurs because:

1. Player destruction is triggered (e.g., navigation back, component unmount)
2. UI views (SideSeekView, ControlsContainerView) are still visible and accepting touches
3. Touch events propagate to listener callbacks
4. Native SDK has already cleared/nulled internal listeners during teardown
5. NPE occurs: `Attempt to invoke interface method 'void com.jwplayer.ui.g.b()' on a null object reference`

This is a timing issue where UI lifecycle and native SDK lifecycle aren't perfectly synchronized during destruction.

### Are there any points in the code the reviewer needs to double check?

1. **Threading**: The UI disable logic runs on the main thread via `Handler.post()` - verify this doesn't introduce any new timing issues
2. **Flag reset**: The `isDestroying` flag is reset at the end of `destroyPlayer()` - confirm this is safe for component reuse scenarios
3. **Touch blocking completeness**: Review if `setClickable(false)`, `setFocusable(false)`, `setEnabled(false)`, and `setOnTouchListener(null)` fully prevent all touch event propagation

### Are there any Pull Requests open in other repos which need to be merged with this?

No

#### Addresses Issue(s):

Internally raised ticket