### PR TITLE
fix(ios): replace force-unwrap with safe cast in resolveNextPlaylistItem

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -234,8 +234,14 @@ class RNJWPlayerViewManager: RCTViewManager {
             }
             
             if let completion = view.onBeforeNextPlaylistItemCompletion {
+                guard let itemDict = playlistItem as? [String: Any] else {
+                    print("Error: resolveNextPlaylistItem received invalid playlist item data")
+                    completion(nil)
+                    view.onBeforeNextPlaylistItemCompletion = nil
+                    return
+                }
                 do {
-                    let item = try view.getPlayerItem(item: playlistItem as! [String: Any])
+                    let item = try view.getPlayerItem(item: itemDict)
                     completion(item)
                 } catch {
                     print("Error creating JWPlayerItem: \(error)")


### PR DESCRIPTION
### What does this Pull Request do?
Replaces an unsafe force-cast (`as!`) with a safe `guard let` cast in `resolveNextPlaylistItem` in `RNJWPlayerViewManager.swift`. If the playlist item data from JS is unexpectedly not a `[String: Any]`, it now logs an error and completes with `nil` instead of crashing.

### Why is this Pull Request needed?
The force-unwrap `playlistItem as! [String: Any]` will crash the app if unexpected data is passed from the JavaScript layer. Since this data crosses the JS-native bridge, a safe cast is warranted to prevent runtime crashes in production.

### Are there any points in the code the reviewer needs to double check?
Verify that calling `completion(nil)` on the fallback path is acceptable SDK behavior (i.e., that the JW Player SDK handles a `nil` playlist item gracefully and doesn't itself crash).

### Are there any Pull Requests open in other repos which need to be merged with this?
No.

#### Addresses Issue(s):
N/A — Defensive fix found during code review of #211.
