### PR TITLE
fix: normalize iOS seek event properties to match Android and TS types

### DIFF
--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1846,11 +1846,11 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
     }
 
     func jwplayerHasSeeked(_ player:JWPlayer) {
-        self.onSeeked?([:])
+        self.onSeeked?(["position": player.time.position])
     }
     
     func jwplayer(_ player: JWPlayer, seekedFrom oldPosition: TimeInterval, to newPosition: TimeInterval) {
-        self.onSeek?(["from": oldPosition, "to": newPosition])
+        self.onSeek?(["position": oldPosition, "offset": newPosition])
     }
 
     func jwplayer(_ player:JWPlayer, updatedCues cues:[JWCue]) {

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -504,12 +504,12 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerF
 
     override func jwplayer(_ player:JWPlayer, seekedFrom oldPosition:TimeInterval, to newPosition:TimeInterval) {
         super.jwplayer(player, seekedFrom:oldPosition, to:newPosition)
-        parentView?.onSeek?(["from": oldPosition, "to": newPosition])
+        parentView?.onSeek?(["position": oldPosition, "offset": newPosition])
     }
 
     override func jwplayerHasSeeked(_ player:JWPlayer) {
         super.jwplayerHasSeeked(player)
-        parentView?.onSeeked?([:])
+        parentView?.onSeeked?(["position": player.time.position])
     }
 
     override func jwplayer(_ player:JWPlayer, playbackRateChangedTo rate:Double, at time:TimeInterval) {


### PR DESCRIPTION
## Summary
- **`onSeeked`**: iOS now includes `position` (current playback position after seek completes) via `player.time.position`. Previously sent an empty event payload.
- **`onSeek`**: iOS now sends `position`/`offset` property names instead of `from`/`to`, matching Android and the existing TypeScript type definitions.

Both events now have consistent payloads across iOS and Android.

Closes #223

## Test plan
- [x] Play a video on iOS and seek to a new position — verify `onSeeked` event contains `position` with the correct time value
- [x] Play a video on iOS and initiate a seek — verify `onSeek` event contains `position` (origin) and `offset` (target)
- [x] Repeat on Android to confirm no regressions
- [x] Verify TypeScript types match the actual event payloads on both platforms