### PR TITLE
Upgrade native SDKs — iOS 4.26.0 / Android 4.25.0

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - JWPlayerKit (4.25.2)
+  - JWPlayerKit (4.26.0)
   - Protobuf (3.29.6)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -1644,10 +1644,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNJWPlayer (1.4.0):
+  - RNJWPlayer (1.4.1):
     - google-cast-sdk (= 4.8.3)
     - GoogleAds-IMA-iOS-SDK (= 3.22.1)
-    - JWPlayerKit (= 4.25.2)
+    - JWPlayerKit (= 4.26.0)
     - React-Core
   - RNScreens (4.10.0):
     - DoubleConversion
@@ -1968,7 +1968,7 @@ SPEC CHECKSUMS:
   google-cast-sdk: 1fb6724e94cc5ff23b359176e0cf6360586bb97a
   GoogleAds-IMA-iOS-SDK: 160c3616b8371b58016e30aaf441e71d6d9e8f7d
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  JWPlayerKit: 4bd4d8fd4c62cda9888415e1340e16d010981cd9
+  JWPlayerKit: 4834e5861ae15654a5b02da8338c574688179784
   Protobuf: 8d5596f7468be5400861a6bbfb2dfe9d0d1cde34
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
@@ -2034,7 +2034,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNJWPlayer: 290598f5151baecd9f26b7b2f5ae0ab5b5e3caab
+  RNJWPlayer: 241bb55b4415f0530b30b881dfba54e06fc1914d
   RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
   RNVectorIcons: bd818296a51dc2bb8c3bd97a3ca399df1afe216d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "15.0"
+  s.platform     = :ios, "15.6"
   s.source       = { :git => "https://github.com/jwplayer/jwplayer-react-native.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/RNJWPlayer/*.{h,m,swift}"
   if defined?($RNJWPlayerUseLocalSDK)

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     Pod::UI.puts "RNJWPlayer: using local JWPlayerKit.xcframework"
     s.vendored_frameworks = 'ios/frameworks/JWPlayerKit.xcframework'
   else
-    s.dependency   'JWPlayerKit', '4.25.2'
+    s.dependency   'JWPlayerKit', '4.26.0'
   end
   s.dependency   'React-Core'
   s.static_framework = true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ allprojects {
     }
 }
 
-def jwPlayerVersion = "4.24.2"
+def jwPlayerVersion = "4.25.0"
 def useLocalAARs = false // Set to false to revert to Maven dependencies
 def exoplayerVersion = "2.18.7" // Deprecated. Use Media3 when targeting JW SDK > 4.16.0
 def media3ExoVersion = "1.4.1"


### PR DESCRIPTION
## Summary
- Bumps `JWPlayerKit` to **4.26.0** and JW Android SDK to **4.25.0**
- No bridge surface changes — all deltas in the native ranges are additive or fixes
- RN consumers inherit every fix shipped in the two native releases

Changelogs:
- Android: https://docs.jwplayer.com/players/docs/android-changelog
- iOS: https://docs.jwplayer.com/players/docs/ios-changelog

## Inherited fixes

### iOS 4.25.2 → 4.26.0
- Quality menu: filter out audio-only sources, label HLS as **Auto**, preserve captions after a quality switch
- Fix accessibility label text when player item title/description are empty
- Dispatch `jwplayerIsReady` notification on the main queue
- Fix toolbar transparency on the error screen when `UIDesignRequiresCompatibility` is true
- Public `JWJSONParser.playlistItems(from:)` API
- Add `bufferHealth` to `JWTimeData` for live-stream buffer metrics
- Rename `deviceId` / `deviceModel` to camelCase

### Android 4.24.2 → 4.25.0
- Fix user-interaction crash during player teardown
- Fix `ForegroundServiceStartNotAllowedException` crash on API 31+
- Fix oversized captions when the player view is taller than the video
- Fix VAST progress bar freeze after an ad error
- Fix live audio stream showing an infinite spinner with missing controls
- Fix IMA preroll playing simultaneously with content on replay
- Expose `bufferedPosition` on `BufferChangeEvent` for live-stream buffer health
- Add ad tag macro replacement for IMA ads

## New native APIs available (future work)
- Update playlist item title / description / poster image without reloading (iOS `updateItemMetadata`, Android `setPlaylistItemMetadata`)