### PR TITLE
Add setPlaylistItemMetadata for live-stream metadata updates

### DIFF
--- a/Example/app/jsx/App.tsx
+++ b/Example/app/jsx/App.tsx
@@ -18,6 +18,7 @@ import SourcesExample from './screens/SourcesExample';
 import YoutubeExample from './screens/YoutubeExample';
 import PlayerInModal from './screens/PlayerInModal';
 import GlobalPlayerExample from './screens/GlobalPlayerExample';
+import PlaylistItemMetadataExample from './screens/PlaylistItemMetadataExample';
 
 const Stack = createNativeStackNavigator();
 
@@ -44,6 +45,7 @@ export default class App extends Component {
             <Stack.Screen name="Sources" component={SourcesExample} />
             <Stack.Screen name="Youtube" component={YoutubeExample} />
             <Stack.Screen name="Global Player" component={GlobalPlayerExample} />
+            <Stack.Screen name="Item Metadata" component={PlaylistItemMetadataExample} />
             <Stack.Screen name="TypeScript Example" component={TypeScriptExample} />
           </Stack.Navigator>
         </NavigationContainer>

--- a/Example/app/jsx/screens/Home.js
+++ b/Example/app/jsx/screens/Home.js
@@ -20,7 +20,7 @@ function formatBuildInfo(info) {
   return `v${info.version} (dev: ${info.branch} @ ${info.commit}${dirty})`;
 }
 
-const SCREENS = ['TypeScript Example', 'Single', 'On Before Next Playlist Item', 'Modal', 'List', 'DRM', 'Local', 'Sources', 'Youtube', 'Global Player'];
+const SCREENS = ['TypeScript Example', 'Single', 'On Before Next Playlist Item', 'Modal', 'List', 'DRM', 'Local', 'Sources', 'Youtube', 'Global Player', 'Item Metadata'];
 
 export default () => {
   const navigation = useNavigation();

--- a/Example/app/jsx/screens/PlaylistItemMetadataExample.js
+++ b/Example/app/jsx/screens/PlaylistItemMetadataExample.js
@@ -1,0 +1,113 @@
+import React, {useRef, useState} from 'react';
+import {StyleSheet, Text, View, Pressable, Platform} from 'react-native';
+import Player from '../components/Player';
+import {globalStyles} from '../../ui/styles/global.style';
+
+const SEGMENTS = [
+  {
+    title: 'Morning Show — Top of Hour',
+    description: 'News roundup and weather.',
+    image: 'https://picsum.photos/id/1015/640/360',
+  },
+  {
+    title: 'Live Interview — Featured Guest',
+    description: 'In-depth conversation about the day\'s headlines.',
+    image: 'https://picsum.photos/id/1025/640/360',
+  },
+  {
+    title: 'Music Hour — Segment 3',
+    description: 'Back-to-back tracks with zero commercial interruption.',
+    image: 'https://picsum.photos/id/1043/640/360',
+  },
+];
+
+export default () => {
+  const playerRef = useRef(null);
+  const [segmentIndex, setSegmentIndex] = useState(0);
+  const [lastEvent, setLastEvent] = useState(null);
+
+  const jwConfig = {
+    title: SEGMENTS[0].title,
+    playlist: [
+      {
+        title: SEGMENTS[0].title,
+        description: SEGMENTS[0].description,
+        image: SEGMENTS[0].image,
+        file: 'https://content.bitsontherun.com/videos/q1fx20VZ-52qL9xLP.mp4',
+      },
+    ],
+  };
+
+  const applyNextSegment = () => {
+    const next = (segmentIndex + 1) % SEGMENTS.length;
+    setSegmentIndex(next);
+    // refreshNotification: temporary workaround so the Android background-audio notification
+    // rebuilds with the new metadata. Drop this flag once the JW Android SDK refreshes it natively.
+    playerRef.current?.setPlaylistItemMetadata({
+      ...SEGMENTS[next],
+      refreshNotification: true,
+    });
+  };
+
+  const onPlaylistItemMetadataChanged = e => {
+    const {index, playlistItem} = e.nativeEvent;
+    setLastEvent({index, item: playlistItem});
+  };
+
+  return (
+    <View style={globalStyles.container}>
+      <View style={globalStyles.subContainer}>
+        <View style={globalStyles.playerContainer}>
+          <Player
+            ref={playerRef}
+            style={{flex: 1}}
+            config={{autostart: false, backgroundAudioEnabled: true, ...jwConfig}}
+            onPlaylistItemMetadataChanged={onPlaylistItemMetadataChanged}
+          />
+        </View>
+      </View>
+      <Text style={styles.label}>
+        Current segment: {SEGMENTS[segmentIndex].title}
+      </Text>
+      <Pressable style={styles.button} onPress={applyNextSegment}>
+        <Text style={styles.buttonText}>Update metadata (cycle segments)</Text>
+      </Pressable>
+      {lastEvent ? (
+        <Text style={styles.event}>
+          onPlaylistItemMetadataChanged fired (index {lastEvent.index})
+        </Text>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  label: {
+    textAlign: 'center',
+    fontSize: 14,
+    marginTop: 12,
+    color: '#333',
+    paddingHorizontal: 16,
+  },
+  button: {
+    marginTop: 16,
+    marginHorizontal: 24,
+    backgroundColor: '#808080',
+    borderRadius: 20,
+  },
+  buttonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+    margin: 16,
+    textAlign: 'center',
+  },
+  event: {
+    marginTop: 12,
+    textAlign: 'center',
+    color: '#2a7',
+    fontSize: 12,
+    paddingHorizontal: 16,
+    ...(Platform.OS === 'ios' && {fontFamily: 'Menlo'}),
+  },
+});

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
@@ -457,6 +457,25 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
         });
     }
 
+    @ReactMethod
+    public void setPlaylistItemMetadata(final int reactTag,
+                                        final String title,
+                                        final String description,
+                                        final String image,
+                                        final boolean refreshNotification) {
+        new Handler(Looper.getMainLooper()).post(() -> {
+            RNJWPlayerView playerView = getPlayerView(reactTag);
+            if (playerView != null && playerView.mPlayerView != null) {
+                playerView.mPlayerView.getPlayer().setPlaylistItemMetadata(title, description, image);
+                // Temporary workaround: cycle the MediaServiceController so the foreground-service
+                // Notification rebuilds from the updated MediaSession metadata.
+                if (refreshNotification) {
+                    playerView.refreshBackgroundAudioNotification();
+                }
+            }
+        });
+    }
+
     private int stateToInt(PlayerState playerState) {
         switch (playerState) {
             case IDLE:

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerView.java
@@ -107,6 +107,7 @@ import com.jwplayer.pub.api.events.PlaylistItemEvent;
 import com.jwplayer.pub.api.events.ReadyEvent;
 import com.jwplayer.pub.api.events.SeekEvent;
 import com.jwplayer.pub.api.events.SeekedEvent;
+import com.jwplayer.pub.api.events.PlaylistItemMetadataChangedEvent;
 import com.jwplayer.pub.api.events.SetupErrorEvent;
 import com.jwplayer.pub.api.events.TimeEvent;
 import com.jwplayer.pub.api.events.listeners.AdvertisingEvents;
@@ -146,6 +147,7 @@ public class RNJWPlayerView extends RelativeLayout implements
         VideoPlayerEvents.OnTimeListener,
         VideoPlayerEvents.OnPlaylistListener,
         VideoPlayerEvents.OnPlaylistItemListener,
+        VideoPlayerEvents.OnPlaylistItemMetadataChangedListener,
         VideoPlayerEvents.OnPlaylistCompleteListener,
         VideoPlayerEvents.OnAudioTracksListener,
         VideoPlayerEvents.OnAudioTrackChangedListener,
@@ -256,6 +258,33 @@ public class RNJWPlayerView extends RelativeLayout implements
                 mMediaServiceController.bindService();
             }
         }
+    }
+
+    /**
+     * Temporary workaround for a JW Android SDK limitation: setPlaylistItemMetadata updates
+     * the MediaSessionCompat metadata but does not rebuild the foreground-service Notification,
+     * so the lock-screen / shade continues to show the old title / description / poster.
+     *
+     * Cycling the MediaServiceController forces MediaService.doStartForeground() to run
+     * NotificationHelper.createNotification() again, which reads the (already-updated) session
+     * text and rebuilds the visible notification. Expect a brief notification flicker and a
+     * momentary allowBackgroundAudio(false)→(true) transition while the service rebinds.
+     *
+     * Known limitation: the poster image is downloaded asynchronously by the SDK's internal
+     * MediaSessionHelper, and cycling the service resets that helper — so the rebuilt
+     * notification typically shows the previous poster. The poster refreshes on the next
+     * playback state change (pause/play, seek).
+     *
+     * Remove this workaround once the JW Android SDK refreshes the notification natively.
+     */
+    void refreshBackgroundAudioNotification() {
+        if (!backgroundAudioEnabled || mPlayer == null || mActivity == null) {
+            return;
+        }
+        doUnbindService();
+        mMediaServiceController = new MediaServiceController.Builder((AppCompatActivity) mActivity, mPlayer)
+                .build();
+        doBindService();
     }
 
     private void doUnbindService() {
@@ -431,6 +460,7 @@ public class RNJWPlayerView extends RelativeLayout implements
                     EventType.TIME,
                     EventType.PLAYLIST,
                     EventType.PLAYLIST_ITEM,
+                    EventType.PLAYLIST_ITEM_METADATA_CHANGED,
                     EventType.PLAYLIST_COMPLETE,
                     EventType.FIRST_FRAME,
                     EventType.CONTROLS,
@@ -521,6 +551,7 @@ public class RNJWPlayerView extends RelativeLayout implements
                     EventType.AUDIO_TRACK_CHANGED,
                     EventType.PLAYLIST,
                     EventType.PLAYLIST_ITEM,
+                    EventType.PLAYLIST_ITEM_METADATA_CHANGED,
                     EventType.PLAYLIST_COMPLETE,
                     EventType.FIRST_FRAME,
                     EventType.CONTROLS,
@@ -2087,6 +2118,17 @@ public class RNJWPlayerView extends RelativeLayout implements
     @Override
     public void onPlaylist(PlaylistEvent playlistEvent) {
 
+    }
+
+    @Override
+    public void onPlaylistItemMetadataChanged(PlaylistItemMetadataChangedEvent playlistItemMetadataChangedEvent) {
+        WritableMap event = Arguments.createMap();
+        event.putString("message", "onPlaylistItemMetadataChanged");
+        event.putInt("index", playlistItemMetadataChangedEvent.getIndex());
+        Gson gson = new Gson();
+        String json = gson.toJson(playlistItemMetadataChangedEvent.getPlaylistItem());
+        event.putString("playlistItem", json);
+        getReactContext().getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "topPlaylistItemMetadataChanged", event);
     }
 
     @Override

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerViewManager.java
@@ -149,6 +149,10 @@ public class RNJWPlayerViewManager extends SimpleViewManager<RNJWPlayerView> {
                     MapBuilder.of(
                             "phasedRegistrationNames",
                             MapBuilder.of("bubbled", "onPlaylistItem")))
+            .put("topPlaylistItemMetadataChanged",
+                    MapBuilder.of(
+                            "phasedRegistrationNames",
+                            MapBuilder.of("bubbled", "onPlaylistItemMetadataChanged")))
             .put("topSeek",
                     MapBuilder.of(
                             "phasedRegistrationNames",

--- a/index.d.ts
+++ b/index.d.ts
@@ -539,6 +539,7 @@ declare module "@jwplayer/jwplayer-react-native" {
     onControlBarVisible?: (event: BaseEvent<ControlBarVisibleEventProps>) => void;
     onPlaylistComplete?: () => void;
     onPlaylistItem?: (event: BaseEvent<PlaylistItemEventProps>) => void;
+    onPlaylistItemMetadataChanged?: (event: BaseEvent<PlaylistItemEventProps>) => void;
     onCaptionsChanged?: (event: BaseEvent<CaptionsChangedEventProps>) => void;
     onCaptionsList?: (event: BaseEvent<CaptionsListEventProps>) => void;
     onAudioTracks?: () => void;
@@ -618,6 +619,33 @@ declare module "@jwplayer/jwplayer-react-native" {
      * @param playlistUrl URL for playlist to load (format for response: json)
      */
     loadPlaylistWithUrl(playlistUrl: string): void;
+    /**
+     * Updates the currently playing playlist item's metadata without reloading.
+     * Only non-null fields are applied; omitted fields leave existing values unchanged.
+     * Fires `onPlaylistItemMetadataChanged` with the updated item on both platforms.
+     *
+     * @param metadata.refreshNotification **Android-only, temporary workaround.**
+     *   When `true` on Android with `backgroundAudioEnabled: true`, the RN bridge cycles the
+     *   foreground MediaService after updating metadata so the lock-screen / notification shade
+     *   rebuilds with the new title and description. Without this flag the JW Android SDK
+     *   updates the MediaSession metadata but leaves the visible notification stale. Expect a
+     *   brief notification flicker and a momentary audio-focus transition while the service
+     *   rebinds.
+     *
+     *   Known limitation: the poster image is downloaded asynchronously by the SDK, so the
+     *   rebuilt notification typically still shows the previous poster. The poster refreshes
+     *   on the next playback state change (pause/play, seek).
+     *
+     *   Remove this flag from your call site once a future JW Android SDK release refreshes the
+     *   notification natively. No-op on iOS — JWPlayerKit already refreshes the lock-screen
+     *   controls via LockScreenControlsHandler.
+     */
+    setPlaylistItemMetadata(metadata: {
+        title?: string | null;
+        description?: string | null;
+        image?: string | null;
+        refreshNotification?: boolean;
+    }): void;
     setFullscreen(fullScreen: boolean): void;
     time(): Promise<number | null>;
     position(): Promise<number | null>;

--- a/index.js
+++ b/index.js
@@ -371,6 +371,7 @@ export default class JWPlayer extends Component {
 		onSeeked: PropTypes.func,
 		onRateChanged: PropTypes.func,
 		onPlaylistItem: PropTypes.func,
+		onPlaylistItemMetadataChanged: PropTypes.func,
 		onControlBarVisible: PropTypes.func,
 		onPlaylistComplete: PropTypes.func,
 		getAudioTracks: PropTypes.func,
@@ -539,6 +540,23 @@ export default class JWPlayer extends Component {
 	loadPlaylistWithUrl(playlistUrl) {
 		if (RNJWPlayerManager)
 			RNJWPlayerManager.loadPlaylistWithUrl(this.getRNJWPlayerBridgeHandle(), playlistUrl);
+	}
+
+	setPlaylistItemMetadata(metadata) {
+		if (!RNJWPlayerManager) return;
+		const {
+			title = null,
+			description = null,
+			image = null,
+			refreshNotification = false,
+		} = metadata || {};
+		RNJWPlayerManager.setPlaylistItemMetadata(
+			this.getRNJWPlayerBridgeHandle(),
+			title,
+			description,
+			image,
+			refreshNotification
+		);
 	}
 
 	setFullscreen(fullscreen) {

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -49,6 +49,7 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
     var onBeforeNextPlaylistItemCompletion: ((JWPlayerItem?) -> ())?
     var pendingConfigAfterPlaylistItemCallback: [String: Any]?
     var hasTriggeredFirstPlaylistItemCallback: Bool = false
+    var currentPlayingIndex: Int = 0
     
     @objc var onBuffer: RCTDirectEventBlock?
     @objc var onUpdateBuffer: RCTDirectEventBlock?
@@ -58,6 +59,7 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
     @objc var onPause: RCTDirectEventBlock?
     @objc var onIdle: RCTDirectEventBlock?
     @objc var onPlaylistItem: RCTDirectEventBlock?
+    @objc var onPlaylistItemMetadataChanged: RCTDirectEventBlock?
     @objc var onLoaded: RCTDirectEventBlock?
     @objc var onVisible: RCTDirectEventBlock?
     @objc var onTime: RCTDirectEventBlock?
@@ -1759,6 +1761,8 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
 //            "adSchedule": schedDict,
 //            "tracks": trackDict
 //        ]
+
+        self.currentPlayingIndex = Int(index)
 
         do {
             let data:Data! = try JSONSerialization.data(withJSONObject: item.toJSONObject(), options:.prettyPrinted)

--- a/ios/RNJWPlayer/RNJWPlayerViewManager.m
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.m
@@ -29,6 +29,7 @@ RCT_EXPORT_VIEW_PROPERTY(onBuffer, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onUpdateBuffer, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onIdle, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPlaylistItem, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onPlaylistItemMetadataChanged, RCTDirectEventBlock);
 
 /* av events */
 RCT_EXPORT_VIEW_PROPERTY(onAudioTracks, RCTDirectEventBlock);
@@ -141,5 +142,7 @@ RCT_EXTERN_METHOD(recreatePlayerWithConfig: (nonnull NSNumber *)reactTag: (nonnu
 RCT_EXTERN_METHOD(loadPlaylistWithUrl: (nonnull NSNumber *)reactTag: (nonnull NSString *)playlist)
 
 RCT_EXTERN_METHOD(setFullscreen: (nonnull NSNumber *)reactTag: (BOOL)fullscreen)
+
+RCT_EXTERN_METHOD(setPlaylistItemMetadata: (nonnull NSNumber *)reactTag : (NSString *)title : (NSString *)description : (NSString *)image : (BOOL)refreshNotification)
 
 @end

--- a/ios/RNJWPlayer/RNJWPlayerViewManager.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewManager.swift
@@ -621,5 +621,42 @@ class RNJWPlayerViewManager: RCTViewManager {
             }
         }
     }
-    
+
+    // The `refreshNotification` parameter is part of the JS API for parity with an
+    // Android-side workaround. On iOS JWPlayerKit already refreshes MPNowPlayingInfoCenter /
+    // the Control Center via LockScreenControlsHandler when updateItemMetadata is called,
+    // so this flag is accepted and ignored here.
+    @objc func setPlaylistItemMetadata(_ reactTag: NSNumber, _ title: String?, _ description: String?, _ image: String?, _ refreshNotification: Bool) {
+        DispatchQueue.main.async {
+            guard let view = self.getPlayerView(reactTag: reactTag) else {
+                print("Invalid view returned from registry, expecting RNJWPlayerView")
+                return
+            }
+
+            let posterURL = image.flatMap { URL(string: $0) }
+            var updatedItem: JWPlayerItem?
+
+            if let playerView = view.playerView {
+                playerView.player.updateItemMetadata(title: title, description: description, posterImage: posterURL)
+                updatedItem = playerView.player.currentItem
+            } else if let playerViewController = view.playerViewController {
+                playerViewController.player.updateItemMetadata(title: title, description: description, posterImage: posterURL)
+                updatedItem = playerViewController.player.currentItem
+            } else {
+                return
+            }
+
+            guard let item = updatedItem else { return }
+            do {
+                let data = try JSONSerialization.data(withJSONObject: item.toJSONObject(), options: .prettyPrinted)
+                view.onPlaylistItemMetadataChanged?([
+                    "playlistItem": String(data: data, encoding: .utf8) as Any,
+                    "index": view.currentPlayingIndex
+                ])
+            } catch {
+                print("Error serializing updated playlist item: \(error)")
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Adds `setPlaylistItemMetadata({title, description, image})` on both platforms for updating the currently playing item's metadata without a reload. Fires `onPlaylistItemMetadataChanged` with the updated item.

Android-only `refreshNotification` opt-in flag cycles the foreground MediaService so the background-audio notification rebuilds with the new title/description. Temporary workaround for a known JW Android SDK limitation — drop the flag once a future SDK release refreshes the notification natively. See the TS doc for details and known poster-lag behavior.

Includes an Item Metadata example screen demonstrating mid-playback cycling.