### PR TITLE
chore: add android/libs and ios/Frameworks to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,8 @@ android/.gradle
 android/.settings
 android/.classpath
 android/.project
+android/libs
+ios/Frameworks
 *.iml
 .eslintrc
 yarn-error.log


### PR DESCRIPTION
### What does this Pull Request do?

Adds `android/libs` and `ios/Frameworks` to `.npmignore` so local-dev SDK binaries can't leak into future `npm publish` tarballs.

### Why is this Pull Request needed?

Both directories are opt-in local-dev paths (`\$RNJWPlayerUseLocalSDK` for iOS, `useLocalAARs` for Android). They're not tracked in git, but `npm pack` packs from the working tree — so if the binaries are present at publish time, they get shipped.

This was caught during the v1.5.0 publish: the initial `npm publish --dry-run` was **25 MB / 200 files** vs v1.4.1's published **464 KB / 36 files**. After moving the local binaries aside, the tarball dropped back to the expected size and v1.5.0 shipped clean. This patch makes the protection permanent.

### Are there any points in the code the reviewer needs to double check?

- Confirm the `.npmignore` entries don't collide with any intended published path. Neither `android/libs` nor `ios/Frameworks` is tracked in git, so there is nothing legitimate to exclude.

### Are there any Pull Requests open in other repos which need to be merged with this?

No.