### PR TITLE
chore: bump JWPlayerKit to 4.26.1 (iOS) and JW SDK to 4.25.1 (Android)

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - JWPlayerKit (4.26.0)
+  - JWPlayerKit (4.26.1)
   - Protobuf (3.29.6)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -1647,7 +1647,7 @@ PODS:
   - RNJWPlayer (1.5.0):
     - google-cast-sdk (= 4.8.3)
     - GoogleAds-IMA-iOS-SDK (= 3.22.1)
-    - JWPlayerKit (= 4.26.0)
+    - JWPlayerKit (= 4.26.1)
     - React-Core
   - RNScreens (4.10.0):
     - DoubleConversion
@@ -1968,7 +1968,7 @@ SPEC CHECKSUMS:
   google-cast-sdk: 1fb6724e94cc5ff23b359176e0cf6360586bb97a
   GoogleAds-IMA-iOS-SDK: 160c3616b8371b58016e30aaf441e71d6d9e8f7d
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  JWPlayerKit: 4834e5861ae15654a5b02da8338c574688179784
+  JWPlayerKit: 9927b3f9a2f8b3f26354daf9e141487dd30550eb
   Protobuf: 8d5596f7468be5400861a6bbfb2dfe9d0d1cde34
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
@@ -2034,7 +2034,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNJWPlayer: 7ab46641d8c534c33f68e8c6b4e7e715fe602a6b
+  RNJWPlayer: caec6ba66835661f00f02f0f2e526604489bd2dc
   RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
   RNVectorIcons: bd818296a51dc2bb8c3bd97a3ca399df1afe216d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     Pod::UI.puts "RNJWPlayer: using local JWPlayerKit.xcframework"
     s.vendored_frameworks = 'ios/frameworks/JWPlayerKit.xcframework'
   else
-    s.dependency   'JWPlayerKit', '4.26.0'
+    s.dependency   'JWPlayerKit', '4.26.1'
   end
   s.dependency   'React-Core'
   s.static_framework = true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ allprojects {
     }
 }
 
-def jwPlayerVersion = "4.25.0"
+def jwPlayerVersion = "4.25.1"
 def useLocalAARs = false // Set to false to revert to Maven dependencies
 def exoplayerVersion = "2.18.7" // Deprecated. Use Media3 when targeting JW SDK > 4.16.0
 def media3ExoVersion = "1.4.1"


### PR DESCRIPTION
## Summary
- Bumps native SDK pins to the latest patch releases:
  - iOS `JWPlayerKit` `4.26.0` → `4.26.1` ([changelog](https://docs.jwplayer.com/players/docs/ios-changelog#4261))
  - Android `jwPlayerVersion` `4.25.0` → `4.25.1` ([changelog](https://docs.jwplayer.com/players/docs/android-changelog#4251))
- Regenerates `Example/ios/Podfile.lock` via `pod update JWPlayerKit`
- All upstream changes are internal SDK fixes — no bridge code changes needed

## Upstream changes picked up

### iOS 4.26.1
- Intermittent AVPlayer crash starting Chromecast session
- Captions: always reload AVPlayerItem on content load
- Chromecast playlist progression broken after first item
- Stuck "Playing on AirPlay" overlay after media swap
- Lock-screen artwork distortion for non-square posters
- Headless player JS upgraded to 8.48.1

### Android 4.25.1
- DAI Learn More click-through pause/resume
- Chromecast caption disable and on-screen icon state sync
- Headless player JS upgraded to 8.48.1

## Test plan
- [ ] iOS Example app builds against JWPlayerKit 4.26.1
- [ ] Android Example app builds against JW SDK 4.25.1
- [ ] Basic playback smoke test on both platforms
- [ ] Spot-check Chromecast on both platforms (multiple upstream fixes in this area)
- [ ] Spot-check captions / DAI ad click-through where applicable