### PR TITLE
fix(ios): present JWPlayerKit menus over host tab bar (#93)

### DIFF
--- a/Example/app/jsx/App.tsx
+++ b/Example/app/jsx/App.tsx
@@ -19,6 +19,7 @@ import YoutubeExample from './screens/YoutubeExample';
 import PlayerInModal from './screens/PlayerInModal';
 import GlobalPlayerExample from './screens/GlobalPlayerExample';
 import PlaylistItemMetadataExample from './screens/PlaylistItemMetadataExample';
+import BottomTabOverlapExample from './screens/BottomTabOverlapExample';
 
 const Stack = createNativeStackNavigator();
 
@@ -47,6 +48,7 @@ export default class App extends Component {
             <Stack.Screen name="Global Player" component={GlobalPlayerExample} />
             <Stack.Screen name="Item Metadata" component={PlaylistItemMetadataExample} />
             <Stack.Screen name="TypeScript Example" component={TypeScriptExample} />
+            <Stack.Screen name="Bottom Tab Overlap (Issue #93)" component={BottomTabOverlapExample} />
           </Stack.Navigator>
         </NavigationContainer>
       </SafeAreaProvider>

--- a/Example/app/jsx/screens/BottomTabOverlapExample.js
+++ b/Example/app/jsx/screens/BottomTabOverlapExample.js
@@ -1,0 +1,115 @@
+import React, {useRef} from 'react';
+import {StyleSheet, View, Text} from 'react-native';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import Player from '../components/Player';
+
+// Demonstrates the fix for GitHub issue #93.
+//
+// On iOS, when a JWPlayer is rendered under a @react-navigation/bottom-tabs
+// navigator, JWPlayerKit's quality / audio / captions menu used to be hidden
+// behind the native tab bar — the menu inflated within the player VC's
+// presentation context, which is clipped by the tab bar chrome.
+//
+// The fix lives in the bridge (ios/RNJWPlayer/RNJWPlayerViewController.swift):
+// `present(_:animated:completion:)` is overridden on RNJWPlayerViewController
+// to forward presentations up to the top-most view controller in the key
+// window, so menus draw over the tab bar.
+//
+// To verify: open this screen, tap the kebab / settings icon in the player
+// controls, choose Quality or Audio & Subtitles. The Close button should be
+// visible above the tab bar.
+
+const Tab = createBottomTabNavigator();
+
+const jwConfig = {
+  title: 'Bottom Tab Overlap Repro',
+  playlist: [
+    {
+      title: 'Sample',
+      file: 'https://content.bitsontherun.com/videos/q1fx20VZ-52qL9xLP.mp4',
+      tracks: [
+        {
+          file: 'https://playertest.longtailvideo.com/caption-files/captions-en.vtt',
+          label: 'English',
+          kind: 'captions',
+          default: true,
+        },
+      ],
+    },
+  ],
+};
+
+const PlayerScreen = () => {
+  const playerRef = useRef(null);
+
+  return (
+    <View style={styles.tabContainer}>
+      <Player
+        ref={playerRef}
+        style={StyleSheet.absoluteFill}
+        config={{
+          autostart: true,
+          styling: {colors: {}},
+          ...jwConfig,
+        }}
+      />
+    </View>
+  );
+};
+
+const InfoTab = () => (
+  <View style={styles.placeholder}>
+    <Text style={styles.placeholderTitle}>Issue #93</Text>
+    <Text style={styles.placeholderText}>
+      Open the Player tab, tap the kebab menu in the player controls, then
+      choose Quality or Audio & Subtitles. The menu's Close button should
+      render above the native tab bar.
+    </Text>
+  </View>
+);
+
+export default () => {
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: '#EC0041',
+      }}>
+      <Tab.Screen
+        name="Player"
+        component={PlayerScreen}
+        options={{tabBarLabel: 'Player'}}
+      />
+      <Tab.Screen
+        name="Info"
+        component={InfoTab}
+        options={{tabBarLabel: 'Info'}}
+      />
+    </Tab.Navigator>
+  );
+};
+
+const styles = StyleSheet.create({
+  tabContainer: {
+    flex: 1,
+    backgroundColor: 'black',
+  },
+  placeholder: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    padding: 24,
+  },
+  placeholderTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  placeholderText: {
+    fontSize: 15,
+    textAlign: 'center',
+    lineHeight: 22,
+    color: '#333',
+  },
+});

--- a/Example/app/jsx/screens/Home.js
+++ b/Example/app/jsx/screens/Home.js
@@ -20,7 +20,7 @@ function formatBuildInfo(info) {
   return `v${info.version} (dev: ${info.branch} @ ${info.commit}${dirty})`;
 }
 
-const SCREENS = ['TypeScript Example', 'Single', 'On Before Next Playlist Item', 'Modal', 'List', 'DRM', 'Local', 'Sources', 'Youtube', 'Global Player', 'Item Metadata'];
+const SCREENS = ['TypeScript Example', 'Single', 'On Before Next Playlist Item', 'Modal', 'List', 'DRM', 'Local', 'Sources', 'Youtube', 'Global Player', 'Item Metadata', 'Bottom Tab Overlap (Issue #93)'];
 
 export default () => {
   const navigation = useNavigation();

--- a/Example/package.json
+++ b/Example/package.json
@@ -17,8 +17,9 @@
   },
   "dependencies": {
     "@jwplayer/jwplayer-react-native": "link:../../jwplayer-react-native",
-    "@react-navigation/native": "7.0.19",
-    "@react-navigation/native-stack": "7.3.3",
+    "@react-navigation/bottom-tabs": "^7.0.0",
+    "@react-navigation/native": "^7.2.4",
+    "@react-navigation/native-stack": "^7.3.10",
     "react": "19.0.0",
     "react-native": "0.78.1",
     "react-native-bootsplash": "6.3.4",

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -1882,12 +1882,21 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@react-navigation/core@^7.7.0":
-  version "7.13.7"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.13.7.tgz#1263903a703b5f183a08c22dfc5c3735ac4ef91c"
-  integrity sha512-k2ABo3250vq1ovOh/iVwXS6Hwr5PVRGXoPh/ewVFOOuEKTvOx9i//OBzt8EF+HokBxS2HBRlR2b+aCOmscRqBw==
+"@react-navigation/bottom-tabs@^7.0.0":
+  version "7.16.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-7.16.1.tgz#b57729ae28077489a1c5c49ddc151c3810f6e0f5"
+  integrity sha512-wjFATJmbq0K8B96Ax0JcK2+Eu7syfYvQ5qUd/tgcv8JuCYLwKKqojJMAl31qdjpKqFG09pQ6TSdEDHOek60CAA==
   dependencies:
-    "@react-navigation/routers" "^7.5.3"
+    "@react-navigation/elements" "^2.9.18"
+    color "^4.2.3"
+    sf-symbols-typescript "^2.1.0"
+
+"@react-navigation/core@^7.17.4":
+  version "7.17.4"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.17.4.tgz#704f650d0be01f5a1bfd2f17c96825ee27ab6bb2"
+  integrity sha512-Rv9E2oNNQEkPGpmu9q+vJwGJRSQR6LBg5L+Yo1QHjtwGbHUbjkIKOdYymDZoZYgNzX2OD4rAIlfuzbDKa3cCeA==
+  dependencies:
+    "@react-navigation/routers" "^7.5.5"
     escape-string-regexp "^4.0.0"
     fast-deep-equal "^3.1.3"
     nanoid "^3.3.11"
@@ -1896,38 +1905,40 @@
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/elements@^2.3.1":
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.9.3.tgz#505ae38af347a0bc5326155318a3d9a54e2071e3"
-  integrity sha512-3+eyvWiVPIEf6tN9UdduhOEHcTuNe3R5WovgiVkfH9+jApHMTZDc2loePTpY/i2HDJhObhhChpJzO6BVjrpdYQ==
+"@react-navigation/elements@^2.9.18":
+  version "2.9.18"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.9.18.tgz#6197631c44dde42c63b623df4f4d3276611aa1b2"
+  integrity sha512-mKEvDr6CkCVYZSb8W9WubNseihL+1c8M7ktZJCTCbMk8rQgdQfkdRNwpSUQKspdGpUHCb9cyzvaiuzl1NtjVgw==
   dependencies:
     color "^4.2.3"
     use-latest-callback "^0.2.4"
     use-sync-external-store "^1.5.0"
 
-"@react-navigation/native-stack@7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.3.3.tgz#0b05b5aea07088ce383ae1a553eb8761fc732b49"
-  integrity sha512-piUO4MzYPrdiolrB/FKU25216MPQHd+90tIE2uwqioRLzEAcv78f0Pugi2Hp7RSOMmNjLIIGk6QMwZqr/ot9KQ==
+"@react-navigation/native-stack@^7.3.10":
+  version "7.15.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.15.1.tgz#799120d366dcd6d5d574f65148dec752ca40ab42"
+  integrity sha512-kNrJggwoB/onC0MpZIuZ6qaqeAziFchz+W9txBzhd6qbWmB1OkPVUnu6fWgc6BQc7MeMf59djVmqgX+6kJU1Ug==
   dependencies:
-    "@react-navigation/elements" "^2.3.1"
+    "@react-navigation/elements" "^2.9.18"
+    color "^4.2.3"
+    sf-symbols-typescript "^2.1.0"
     warn-once "^0.1.1"
 
-"@react-navigation/native@7.0.19":
-  version "7.0.19"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.0.19.tgz#3f9c7c809ec19f98d5c88fd895e6f0d33128a174"
-  integrity sha512-6UDTFVM91FIUaXF5OZ7GHb+XZK6yAktqdTOBOtn3goIyafKz0OUo+ukxe+tPGpr+E9ZQjdZDCseIH6HOI/k8rw==
+"@react-navigation/native@^7.2.4":
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.2.4.tgz#3e44077d2ae1b7a6ba8e376b49e1fce6272dbec1"
+  integrity sha512-eWC2D3JjhYLId2fVTZhhCiUpWIaPhO9XyEb7Wq8ElmOHyIODlbOzgZ0rKia02OIsDKr9BzZl2sK1dL70yMxDaw==
   dependencies:
-    "@react-navigation/core" "^7.7.0"
+    "@react-navigation/core" "^7.17.4"
     escape-string-regexp "^4.0.0"
     fast-deep-equal "^3.1.3"
-    nanoid "3.3.8"
-    use-latest-callback "^0.2.1"
+    nanoid "^3.3.11"
+    use-latest-callback "^0.2.4"
 
-"@react-navigation/routers@^7.5.3":
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.3.tgz#8002930ef5f62351be2475d0dffde3ffaee174d7"
-  integrity sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==
+"@react-navigation/routers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.5.5.tgz#04358f1997cc31aa702d01719af274dc123d6025"
+  integrity sha512-9/hhMte12Kgu+pMnLfA4EWJ0OQmIEAMVMX06FPH2yGkEQSQ3JhhCN/GkcRikzQhtEi97VYYQA15umptBUShcOQ==
   dependencies:
     nanoid "^3.3.11"
 
@@ -5600,11 +5611,6 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.3.8:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
-  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
-
 nanoid@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
@@ -6637,6 +6643,11 @@ setprototypeof@~1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+sf-symbols-typescript@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sf-symbols-typescript/-/sf-symbols-typescript-2.2.0.tgz#926d6e0715e3d8784cadf7658431e36581254208"
+  integrity sha512-TPbeg0b7ylrswdGCji8FRGFAKuqbpQlLbL8SOle3j1iHSs5Ob5mhvMAxWN2UItOjgALAB5Zp3fmMfj8mbWvXKw==
+
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
@@ -7344,7 +7355,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-latest-callback@^0.2.1, use-latest-callback@^0.2.4:
+use-latest-callback@^0.2.4:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.2.6.tgz#e5ea752808c86219acc179ace0ae3c1203255e77"
   integrity sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==

--- a/ios/RNJWPlayer/RNJWPlayerViewController.swift
+++ b/ios/RNJWPlayer/RNJWPlayerViewController.swift
@@ -46,6 +46,32 @@ class RNJWPlayerViewController : JWPlayerViewController, JWPlayerViewControllerF
         self.player.contentKeyDataSource = nil
     }
 
+    // Forwards JWPlayerKit's modal presentations (quality / audio / captions
+    // menus, related items, etc.) up to the top-most view controller in the
+    // key window so they draw over host chrome like UITabBarController. See
+    // GitHub issue #93. Falls back to super.present when self is already the
+    // topmost (e.g. when JW fullscreen is the topmost presented VC).
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        assert(Thread.isMainThread, "RNJWPlayerViewController.present must be called on the main thread")
+        if let top = Self.topMostViewController(), top !== self {
+            top.present(viewControllerToPresent, animated: flag, completion: completion)
+        } else {
+            super.present(viewControllerToPresent, animated: flag, completion: completion)
+        }
+    }
+
+    private static func topMostViewController() -> UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first(where: { $0.isKeyWindow })
+        var top = keyWindow?.rootViewController
+        while let presented = top?.presentedViewController {
+            top = presented
+        }
+        return top
+    }
+
     // MARK: - JWPlayer Delegate
 
     override func jwplayerIsReady(_ player:JWPlayer) {


### PR DESCRIPTION
## Summary

Fixes #93 — on iOS, JWPlayerKit's quality / audio / captions menu was hidden behind the native tab bar when the player lives under `@react-navigation/bottom-tabs`. The menu was being presented from the player VC, which is contained inside the tab bar's child VC, so the modal could not draw over the tab bar chrome.

## Fix

`RNJWPlayerViewController.swift` now overrides `present(_:animated:completion:)` to forward modal presentations up to the top-most VC in the key window. Falls back to `super.present` when self is already the topmost (e.g. while JW fullscreen is active).

## Testing

Reviewed against the existing Example app:

- ✅ Issue #93 repro (new `Bottom Tab Overlap (Issue #93)` screen) — menu now draws over the tab bar.
- ✅ Fullscreen menu — edge-to-edge in practice.
- ✅ Fullscreen enter / exit — unchanged.
- ✅ Plain Single example, List example with multiple players — unchanged.

## For @cheynewallace

Could you validate this against your app? From the repo root:

```bash
npm pack
```

Then in your app's directory:

```bash
npm install /absolute/path/to/jwplayer-jwplayer-react-native-<version>.tgz
```

(or `yarn add file:/absolute/path/...` if you use yarn). Rebuild your iOS app and confirm the quality/audio menu's Close button is visible above your tab bar. Thanks!

## Test plan

- [x] Verify menu draws over native tab bar in `Bottom Tab Overlap (Issue #93)` example screen
- [x] Verify fullscreen entry / exit still works
- [x] Verify menu still works in plain (no tab bar) layouts
- [x] Reporter validation via `npm pack` install