### PR TITLE
fix(android): catch IllegalViewOperationException in getPlayerView

### DIFF
--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerModule.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.IllegalViewOperationException;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.jwplayer.pub.api.JWPlayer;
@@ -52,9 +53,15 @@ public class RNJWPlayerModule extends ReactContextBaseJavaModule {
             uiManagerType = UIManagerType.DEFAULT;
         }
         UIManager uiManager = UIManagerHelper.getUIManager(mReactContext, uiManagerType);
-        if (uiManager != null) {
+        if (uiManager == null) {
+            return null;
+        }
+        try {
             return (RNJWPlayerView) uiManager.resolveView(reactTag);
-        } else {
+        } catch (IllegalViewOperationException e) {
+            // Under Fabric, resolveView throws when the view tag is no longer mounted
+            // (e.g. the view was unmounted between Handler.post and the Runnable executing
+            // during backgrounding or navigation). Paper returns null in the same case.
             return null;
         }
     }


### PR DESCRIPTION
Fixes #232.

Under Fabric, `UIManager.resolveView()` throws `IllegalViewOperationException` for an unmounted view tag where Paper returns `null`. The existing null guards at every callsite never run because the exception escapes `getPlayerView` first, killing the app via the main-thread `UncaughtExceptionHandler`.

Wraps `resolveView` in try/catch and returns null on the exception so the existing `playerView != null` guards apply and the call becomes a no-op — matching Paper semantics. Single-helper fix covers all 26 `@ReactMethod` entry points in `RNJWPlayerModule`.

See #232 for the full analysis, stack trace, and affected methods.