### PR TITLE
chore: bump JWPlayerKit to 4.26.2 (iOS)

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - JWPlayerKit (4.26.1)
+  - JWPlayerKit (4.26.2)
   - Protobuf (3.29.6)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -1647,7 +1647,7 @@ PODS:
   - RNJWPlayer (1.5.1):
     - google-cast-sdk (= 4.8.3)
     - GoogleAds-IMA-iOS-SDK (= 3.22.1)
-    - JWPlayerKit (= 4.26.1)
+    - JWPlayerKit (= 4.26.2)
     - React-Core
   - RNScreens (4.10.0):
     - DoubleConversion
@@ -1968,7 +1968,7 @@ SPEC CHECKSUMS:
   google-cast-sdk: 1fb6724e94cc5ff23b359176e0cf6360586bb97a
   GoogleAds-IMA-iOS-SDK: 160c3616b8371b58016e30aaf441e71d6d9e8f7d
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  JWPlayerKit: 9927b3f9a2f8b3f26354daf9e141487dd30550eb
+  JWPlayerKit: 556fe03b0609cd5e93786cf0542626359cbb287d
   Protobuf: 8d5596f7468be5400861a6bbfb2dfe9d0d1cde34
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
@@ -2034,7 +2034,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNJWPlayer: 732b67f0fcc4733080e720ce74a09e75103c241d
+  RNJWPlayer: 681795e47b7bb5f258ffdfd708dd2b27742c9546
   RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
   RNVectorIcons: bd818296a51dc2bb8c3bd97a3ca399df1afe216d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     Pod::UI.puts "RNJWPlayer: using local JWPlayerKit.xcframework"
     s.vendored_frameworks = 'ios/frameworks/JWPlayerKit.xcframework'
   else
-    s.dependency   'JWPlayerKit', '4.26.1'
+    s.dependency   'JWPlayerKit', '4.26.2'
   end
   s.dependency   'React-Core'
   s.static_framework = true


### PR DESCRIPTION
## Summary

Picks up the iOS SDK **4.26.2** patch release. All changes between 4.26.1 and 4.26.2 are internal bug fixes plus one automatic VAST parsing feature — **no bridge API changes are required**, so this is a drop-in version bump (same shape as the 4.26.1 upgrade in #234).

Android stays on **4.25.1** — this is an iOS-only patch release.

## What's in iOS 4.26.2

See the [iOS changelog](https://docs.jwplayer.com/players/docs/ios-changelog).

- **SDK-11924** — Fixed low GAM / IAS / DV viewability on the Google IMA ad path caused by friendly-obstruction misconfiguration.
- **SDK-11897** — Fixed an infinite spinner at the end of a playlist when tapping fast-forward past the final item.
- **SDK-11792** — Added support for the IAB VAST `<Extension type="skippable">` element, allowing 3P ads to be made skippable when `skipoffset` can't be set on the `<Linear>` element. Applied automatically from the VAST response; no host-facing config.

## Changes

- `RNJWPlayer.podspec` — `JWPlayerKit` dependency `4.26.1` → `4.26.2`
- `Example/ios/Podfile.lock` — regenerated via `pod update JWPlayerKit` (new checksum)

## Testing

- `pod update JWPlayerKit` resolves and installs 4.26.2 cleanly in the Example app.