### PR TITLE
chore: bump Android SDK to 4.25.2 + expose liftsVMAPLevelExtensions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ allprojects {
     }
 }
 
-def jwPlayerVersion = "4.25.1"
+def jwPlayerVersion = "4.25.2"
 def useLocalAARs = false // Set to false to revert to Maven dependencies
 def exoplayerVersion = "2.18.7" // Deprecated. Use Media3 when targeting JW SDK > 4.16.0
 def media3ExoVersion = "1.4.1"

--- a/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerAds.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/RNJWPlayerAds.java
@@ -81,6 +81,15 @@ public class RNJWPlayerAds {
             builder.adRules(adRules);
         }
 
+        // NOTE: `liftsVMAPLevelExtensions` is intentionally NOT wired here.
+        // On Android the SDK exposes that setter only on VmapAdvertisingConfig.Builder,
+        // not on VastAdvertisingConfig.Builder (which is all this legacy path builds).
+        // The flag therefore only takes effect via the modern config path, where the
+        // SDK itself parses it in AdvertisingJsonHelper.parseVmapAdvertising and
+        // constructs a VmapAdvertisingConfig. (iOS unifies VAST/VMAP into one
+        // JWAdsAdvertisingConfigBuilder, so it can — and does — wire the flag for both
+        // its modern and legacy paths in RNJWPlayerAds.configureVAST.)
+
         return builder.build();
     }
 

--- a/ios/RNJWPlayer/RNJWPlayerAds.swift
+++ b/ios/RNJWPlayer/RNJWPlayerAds.swift
@@ -32,6 +32,10 @@ class RNJWPlayerAds {
         if let openBrowserOnAdClick = ads["openBrowserOnAdClick"] as? Bool {
             adConfigBuilder.openBrowserOnAdClick(openBrowserOnAdClick)
         }
+
+        if let liftsVMAPLevelExtensions = ads["liftsVMAPLevelExtensions"] as? Bool {
+            adConfigBuilder.liftsVMAPLevelExtensions(liftsVMAPLevelExtensions)
+        }
         
         if let adRulesDict = ads["adRules"] as? [String: Any], let adRules = getAdRules(from: adRulesDict) {
             adConfigBuilder.adRules(adRules)

--- a/ios/RNJWPlayer/RNJWPlayerAds.swift
+++ b/ios/RNJWPlayer/RNJWPlayerAds.swift
@@ -33,6 +33,12 @@ class RNJWPlayerAds {
             adConfigBuilder.openBrowserOnAdClick(openBrowserOnAdClick)
         }
 
+        // iOS exposes liftsVMAPLevelExtensions on JWAdsAdvertisingConfigBuilder, the
+        // single builder backing both VAST and VMAP here, so wiring it once covers the
+        // modern and legacy config paths. (Android differs: the setter lives only on
+        // VmapAdvertisingConfig.Builder, which its legacy path never builds — see the
+        // note in RNJWPlayerAds.java#configureVastAdvertising — so on Android the flag
+        // works through the modern JSON config path only.)
         if let liftsVMAPLevelExtensions = ads["liftsVMAPLevelExtensions"] as? Bool {
             adConfigBuilder.liftsVMAPLevelExtensions(liftsVMAPLevelExtensions)
         }

--- a/types/advertising.d.ts
+++ b/types/advertising.d.ts
@@ -393,6 +393,14 @@ export interface VmapAdvertisingConfig extends BaseAdvertisingConfig {
    * Only affects inline VMAP XML supplied via `tag`/`schedule`; a remote VMAP
    * URL is never modified. Defaults to `false`.
    *
+   * Path support differs by platform because of how each SDK models the config:
+   * - **iOS** — works with both the modern and legacy config paths (the flag lives
+   *   on the single `JWAdsAdvertisingConfigBuilder` that backs VAST and VMAP).
+   * - **Android** — works with the modern config path only. The Android SDK exposes
+   *   the setter solely on `VmapAdvertisingConfig.Builder`, which the legacy
+   *   (`forceLegacyConfig`) path never constructs; use the default modern config to
+   *   set this flag on Android.
+   *
    * @default false
    * @platforms iOS, Android
    */

--- a/types/advertising.d.ts
+++ b/types/advertising.d.ts
@@ -385,6 +385,18 @@ export interface VmapAdvertisingConfig extends BaseAdvertisingConfig {
    * Alternative way to specify VMAP URL (as string)
    */
   schedule?: string;
+
+  /**
+   * Lift a VMAP-level `<vmap:Extensions>` block down into each `<vmap:AdBreak>`
+   * so per-break consumers (e.g. skippable extensions) see it.
+   *
+   * Only affects inline VMAP XML supplied via `tag`/`schedule`; a remote VMAP
+   * URL is never modified. Defaults to `false`.
+   *
+   * @default false
+   * @platforms iOS, Android
+   */
+  liftsVMAPLevelExtensions?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
1. Bumps the pinned JW Player Android SDK `4.25.1` → `4.25.2` in `android/build.gradle`.
2. Exposes the new **`liftsVMAPLevelExtensions`** VMAP advertising prop, supported by both the Android 4.25.2 and iOS 4.26.2 SDKs.

## What's new in Android SDK 4.25.2
- **SDK-11912** Fix side-loaded captions not rendering on track switch
- **SDK-11866** Fix postroll adPosition reporting as PRE
- **SDK-11847** Refresh background-audio notification on metadata change
- **SDK-11793** Add Android-side VMAP-level skippable extension injector

## liftsVMAPLevelExtensions
A VMAP-**inline-only** flag (ignored for remote VMAP URLs) that lifts a VMAP-level `<vmap:Extensions>` block down into each `<vmap:AdBreak>`. Parser support verified on both platforms:

| Platform | Support | Bridge change |
|---|---|---|
| Android | `AdvertisingJsonHelper.parseVmapAdvertising` reads `liftsVMAPLevelExtensions` | None — modern config passes the key through `MapUtil.toJSONObject` → `JsonHelper.parseConfigJson` |
| iOS | `JWAdsAdvertisingConfigBuilder.liftsVMAPLevelExtensions(_:)` on `JWPlayerKit 4.26.2` | Wired in `RNJWPlayerAds.configureVAST` |

### Changes
- `types/advertising.d.ts`: add `liftsVMAPLevelExtensions?: boolean` to `VmapAdvertisingConfig`
- `ios/RNJWPlayer/RNJWPlayerAds.swift`: wire the flag into the VAST builder
- `android/build.gradle`: `4.25.1` → `4.25.2`

## Test plan
- [ ] Example app builds + plays on iOS and Android
- [ ] Inline VMAP XML with a top-level `<vmap:Extensions>` + `liftsVMAPLevelExtensions: true` lifts extensions into each ad break
- [ ] Side-loaded captions render on track switch (Android 4.25.2 fix)