### PR TITLE
chore(android): upgrade to JW SDK 4.26.0 (media3 1.10.0, IMA 3.39.0, compileSdk 36)

### DIFF
--- a/Example/android/build.gradle
+++ b/Example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
+        compileSdkVersion = 36
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,10 +95,10 @@ allprojects {
     }
 }
 
-def jwPlayerVersion = "4.25.2"
+def jwPlayerVersion = "4.26.0"
 def useLocalAARs = false // Set to false to revert to Maven dependencies
 def exoplayerVersion = "2.18.7" // Deprecated. Use Media3 when targeting JW SDK > 4.16.0
-def media3ExoVersion = "1.4.1"
+def media3ExoVersion = "1.10.0"
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
@@ -109,7 +109,7 @@ dependencies {
         implementation fileTree(dir: 'libs', include: ['jwplayer-core.aar', 'jwplayer-common.aar', 'jwplayer-chromecast.aar'])
         if (useIMA) {
             implementation fileTree(dir: 'libs', include: ['jwplayer-ima.aar'])
-            implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.36.0'
+            implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.39.0'
             implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
             coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
         }
@@ -122,7 +122,7 @@ dependencies {
         // Optional: IMA Ads support
         if (useIMA) {
             implementation "com.jwplayer:jwplayer-ima:${safeExtGet('jwPlayerVersion', jwPlayerVersion)}"
-            implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.36.0'
+            implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.39.0'
             implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
             coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
         }


### PR DESCRIPTION
Upgrades the Android side of the React Native wrapper to JW Player Android SDK **4.26.0**.

## Changes
- **Bridge** (`android/build.gradle`): `jwPlayerVersion` 4.25.2 → **4.26.0**, `media3ExoVersion` 1.4.1 → **1.10.0**, Google IMA 3.36.0 → **3.39.0**
- **Example** (`Example/android/build.gradle`): `compileSdk` 35 → **36** (required by media3 1.10.0)

## Notes
- No React Native / React version change needed (Example already on RN 0.78.1 / React 19) and no bridge Java changes — the media3 APIs the bridge uses (`Util.toByteArray`, `ExoMediaDrm`) compile clean against 1.10.0.
- Verified on-device (physical, Android 15): Example builds, installs, and plays against 4.26.0, resolving from production maven.
- iOS side untouched (tracks JWPlayerKit separately); `package.json` not bumped (handled on `release/react-*`).