### PR TITLE
feat: expose liveSyncDuration for live stream playlist items 

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -7,11 +7,11 @@ PODS:
   - glog (0.3.5)
   - google-cast-sdk (4.8.3):
     - Protobuf (~> 3.13)
-  - GoogleAds-IMA-iOS-SDK (3.22.1)
+  - GoogleAds-IMA-iOS-SDK (3.32.0)
   - hermes-engine (0.78.1):
     - hermes-engine/Pre-built (= 0.78.1)
   - hermes-engine/Pre-built (0.78.1)
-  - JWPlayerKit (4.26.2)
+  - JWPlayerKit (4.27.0)
   - Protobuf (3.29.6)
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -1646,8 +1646,8 @@ PODS:
     - Yoga
   - RNJWPlayer (1.6.0):
     - google-cast-sdk (= 4.8.3)
-    - GoogleAds-IMA-iOS-SDK (= 3.22.1)
-    - JWPlayerKit (= 4.26.2)
+    - GoogleAds-IMA-iOS-SDK (= 3.32.0)
+    - JWPlayerKit (= 4.27.0)
     - React-Core
   - RNScreens (4.10.0):
     - DoubleConversion
@@ -1966,79 +1966,79 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   google-cast-sdk: 1fb6724e94cc5ff23b359176e0cf6360586bb97a
-  GoogleAds-IMA-iOS-SDK: 160c3616b8371b58016e30aaf441e71d6d9e8f7d
+  GoogleAds-IMA-iOS-SDK: b1b1e3b8f486cfb7c7a669a58a5380421f3bcaab
   hermes-engine: f493b0a600aed5dc06532141603688a30a5b2f61
-  JWPlayerKit: 556fe03b0609cd5e93786cf0542626359cbb287d
+  JWPlayerKit: f10fe4d7ed61f3c33231990b00e0a7f843bae1a8
   Protobuf: 8d5596f7468be5400861a6bbfb2dfe9d0d1cde34
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 082fbc90409015eac1366795a0b90f8b5cb28efe
   RCTRequired: ca966f4da75b62ce3ea8c538d82cb5ecbb06f12a
   RCTTypeSafety: 2f0bc11f9584fde4c7e6d8b26577c97681051c00
   React: e6035d3a639f6668a18429aaf2fdc0c12b1e7a81
   React-callinvoker: 3740fb1716428dabd205486c818ce6a5999e7f11
-  React-Core: d12b31b149ff71e5054dec137d651a9955569321
-  React-CoreModules: e392c711449f260d9ba7556a264ef5cfacdab3f9
-  React-cxxreact: dcb3c48b13b298a270edefb24d2a9211809ff147
+  React-Core: 91dda08e72d07375f41dc7ea00550804e0198282
+  React-CoreModules: 5ff502f2c460a74f77ec38164db50886516f403e
+  React-cxxreact: a064be4dcb707678007f90d17739f6a677c6c3de
   React-debug: d8d938ee3aecd7ab9c92198324ed33cac3d42566
-  React-defaultsnativemodule: 599c11bfe99a3b88cd1fa2dc478be1b6b0e57be9
-  React-domnativemodule: 4f278903cad707415026dacbb96768704a705569
-  React-Fabric: 9e83424b66a00da675c6684568dc026399746236
-  React-FabricComponents: 26da28dd7115005866fdf2f8d4e294e07dd6e3df
-  React-FabricImage: b60fb253651746de12418e1308b4da2c54b8fde6
+  React-defaultsnativemodule: 3d376ae49e1d6c7952d43453b244e2672dddf818
+  React-domnativemodule: fced39aaec1bad55ee805c6c4d1e1c2bf3bec195
+  React-Fabric: e4c7e4ac2d2d7fd4b68e290ca6bbb4519e029a30
+  React-FabricComponents: 5f4acebfc858863aa8def40aac5255076bc141b0
+  React-FabricImage: 736bf67d1c23985aed2e3c5a09546322501a932e
   React-featureflags: 04a42c3099a4a12fdf34c42b84512b96caaf9d41
-  React-featureflagsnativemodule: 32a69405f053b25640cac519dbb24c5e79185e1b
-  React-graphics: 49bacefc908533e59e1b65ac479bd00c43dad2d0
-  React-hermes: 809429058aa7610601c552556a132df2f446fe0c
-  React-idlecallbacksnativemodule: d6c574b38b6497189dcdb1c4953c049ed93a67d1
-  React-ImageManager: 9cb4d8d83f0d43591f06bd07b1d845144cb9bc72
-  React-jserrorhandler: 5d010f2c65066e682b5973ea0e39bfc7bfdf46fe
-  React-jsi: 0be2628a04b7ab6b60565ccc0e11069c6a3e5a91
-  React-jsiexecutor: cb431019ea945006b0ad62ba34dba8475926eda9
-  React-jsinspector: 094b9197c4aa166c565273b5b80604c3c25f262a
-  React-jsinspectortracing: 5498aaae966956939808ecd72635a6937c7e724d
-  React-jsitracing: 9d28564942b168004da194785024ddc730caf0dc
-  React-logger: 74ddb793d36b48bba176328c7af75e5e656fd405
-  React-Mapbuffer: 39e87693178fd6483bb5ca8b851fae362d49409a
-  React-microtasksnativemodule: b740ebae7fad70aa78bc24cc0dfc15ac9637b6eb
-  react-native-orientation-locker: cc6f357b289a2e0dd2210fea0c52cb8e0727fdaa
-  react-native-safe-area-context: 0f14bce545abcdfbff79ce2e3c78c109f0be283e
-  React-NativeModulesApple: af0571ac115d09c9a669ed45ce6a4ca960598a2d
-  React-perflogger: 26d07766b033f84559bd520e949453dba8bf1cd8
-  React-performancetimeline: 0f3e0b6e2152951257bd8c90f95d527cf4316fa8
+  React-featureflagsnativemodule: 9cce7cfeb11d05545e1414d5936bc2f7d5174099
+  React-graphics: 7dded734538450bc7f7087f7ea212b43ec423900
+  React-hermes: d61c104904d2c5a2cb9390267085c17f284f149e
+  React-idlecallbacksnativemodule: 1f7c073261991e2a729a2512e447402f968894b0
+  React-ImageManager: d37da23b068b037bdf7349c32023883093206b8b
+  React-jserrorhandler: bd0c3efad40d1a0c6791ceeac275fa3076935ffb
+  React-jsi: 183f5f851fee72238c1ac807bbca39f9930d22cf
+  React-jsiexecutor: afee0663c97f2d32188e1b91fe16fc09377b5ce7
+  React-jsinspector: 1fa4b8eb0099e834e501f84d9f3f2bc55ab879f7
+  React-jsinspectortracing: 44669474b19045a41f3e5370fe1e1f09a4fcc159
+  React-jsitracing: 43d3a40ff903f5e036517577992ea15a63e8a257
+  React-logger: 88de26ac2b4ae3ebf55108f4be299f967151d0ec
+  React-Mapbuffer: b6619632c9800e300a9dcfb5139009416cec6392
+  React-microtasksnativemodule: e99c1d7791f5e8d5be370b78e02433e64d2391d8
+  react-native-orientation-locker: 5819fd23ca89cbac0d736fb4314745f62716d517
+  react-native-safe-area-context: 286b3e7b5589795bb85ffc38faf4c0706c48a092
+  React-NativeModulesApple: fb48894de492e6f9a73e53d8f92a6a792e40666c
+  React-perflogger: e1c8cc9ba55dfabb670966d73622eabcfa0ac29e
+  React-performancetimeline: 6f8984a509036b7adc382b8d15193733f88ee749
   React-RCTActionSheet: 9488eac05a056a124f500beaecf0a5bd722b2916
-  React-RCTAnimation: d4fe0beca00060dc3628d81ea65410180974a18a
-  React-RCTAppDelegate: 6c81adc5689b4276368c9dc61eec211b18ca82c0
-  React-RCTBlob: 1b89799400af7ca0ee598fa7d3bcd9d84ab1794d
-  React-RCTFabric: 7dd42c2d2339184896aaa5cf1974d00c6b97875b
-  React-RCTFBReactNativeSpec: 9487cf2e72e2b0da766afe2a71e1afca12e73325
-  React-RCTImage: 7042262e823fe7849f1263f054c24ef2f4394e9d
-  React-RCTLinking: 7cb75b965f19399f67e75f771f7bd6f097c263d1
-  React-RCTNetwork: b9a7eab793a36b3a74d4d184b917e59842a30a58
-  React-RCTSettings: 7866a50ecc34b202d736d1f4b9164bb711a68a9c
-  React-RCTText: ce131e974c81c0ea4a187f24db12b262a1beab01
-  React-RCTVibration: 16c24efa3a7fb96f6147ec129d554cc43b1ab707
+  React-RCTAnimation: 25cab7e810ceffcbecaf80d481e8da88458fe16d
+  React-RCTAppDelegate: bc7081822fadf0ef7b0103ad7a1906d2872b1f4e
+  React-RCTBlob: 878e2cc90c812b6fd0a311d26f16c7a7d6fb3383
+  React-RCTFabric: 99e355c4b6ea75f272484c7c0679ac8a6c565a23
+  React-RCTFBReactNativeSpec: 992688432b262346c956a316b9b554496af4d21e
+  React-RCTImage: 86722acf9b025c586aaf27d7428e8f85a51a32fa
+  React-RCTLinking: e8e3c957074d5d37081e62c87f7c0896c1e9fb29
+  React-RCTNetwork: 49a1ef2960b23016d2e02707612696293e43cee5
+  React-RCTSettings: ad5b561160ea88c2cd117d7546d850840b5aca0a
+  React-RCTText: af6b82a41a437d5dec61946fb3d8fe93c059a039
+  React-RCTVibration: 7894e99bec0902b50dd630347421f03e34560e02
   React-rendererconsistency: 4171665056d2a6039523e5aa8c9f5fbbe9553ad6
-  React-rendererdebug: 9751d74346f583800af42b1fbb0b3561f66b5ff2
+  React-rendererdebug: ae986a32492d41af5da9eaeeaba1bb2d03a67354
   React-rncore: 3e1894f8ebb4759f2d56b450645677547b9e3c52
-  React-RuntimeApple: 0937e0055990b4dd81b2dbb8acc39f209aa6369b
-  React-RuntimeCore: dec19daf6dbb5dad077c8bd2ceb5f612cdd34917
+  React-RuntimeApple: 9f4478a09f952a2037ab6d9cf25822499292634f
+  React-RuntimeCore: 7cf3e480e4724c98bd38c06873fbe8a5297b0e68
   React-runtimeexecutor: f2fc17f0bbfa5a697d94d2f18d7d5f74c8d41c48
-  React-RuntimeHermes: 0e01cd1fbf82f1fabc66d6f8316c7ee35d8dc871
-  React-runtimescheduler: 3f02922ff1cf0d4fdf5c60b868bed4da3b15a504
+  React-RuntimeHermes: 35c9ba6a7fdb2062e977e10bd407d92e85357120
+  React-runtimescheduler: dc52dc73cef622777eba335b5810801041314a7b
   React-timing: 34f46e46507ab2e215d801223f898a1f3d95a7a3
-  React-utils: 6330b3336d328a09ccc89a45d68d1f2588021318
-  ReactAppDependencyProvider: 5da0393968ce2767e79f9fda7caa108592b9b63e
-  ReactCodegen: 82d5bc3e3ad2c8496848554cb2d3b64b03b53420
-  ReactCommon: 269d0d36423fad044eaea49900e88684ac670a16
-  RNBootSplash: 540e4bfcfe3a9c0a2fe5b3d28d5efe0458f8e7cb
-  RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
-  RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNJWPlayer: 126295f9da134ce90c9288a4fd4af9b70c9f779b
-  RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
-  RNVectorIcons: bd818296a51dc2bb8c3bd97a3ca399df1afe216d
+  React-utils: d57a0f7f59e548f1086562acb900fdd4d8758eb1
+  ReactAppDependencyProvider: 8a4769a6193da471cb229cf46e71cd11cd9a4acd
+  ReactCodegen: a5efc9399f08ae7ddf99d222340bf859312b4630
+  ReactCommon: bd309b74bda8850b05e814a0cc6120152783c0c1
+  RNBootSplash: 1d0409dd59f1417c9427ba5aacdc019194b54d29
+  RNDeviceInfo: feea80a690d2bde1fe51461cf548039258bd03f2
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
+  RNGestureHandler: 9b05fab9a0b48fe48c968de7dbb9ca38a2b4f7ab
+  RNJWPlayer: 0a3c2db4935be408be7c0f21ef058b9c9402f752
+  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
+  RNVectorIcons: 14a0c42f16a26bcc3e79a19bc1c5718284b1d469
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: b94ff2d7559cb66837c97a3f394ddb817faad4d6
+  Yoga: dea3cbe52f93ef8f722493a505c1add295fe7fba
 
 PODFILE CHECKSUM: 2c7d5d89ff31a9adfeeefa8316d50a2dc760a5fa
 

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
   end
   if defined?($RNJWPlayerUseGoogleIMA)
     Pod::UI.puts "RNJWPlayer: enable IMA SDK"
-    s.dependency 'GoogleAds-IMA-iOS-SDK', '3.22.1'
+    s.dependency 'GoogleAds-IMA-iOS-SDK', '3.32.0'
     swift_flags << '-D USE_GOOGLE_IMA'
   end
 

--- a/RNJWPlayer.podspec
+++ b/RNJWPlayer.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     Pod::UI.puts "RNJWPlayer: using local JWPlayerKit.xcframework"
     s.vendored_frameworks = 'ios/frameworks/JWPlayerKit.xcframework'
   else
-    s.dependency   'JWPlayerKit', '4.26.2'
+    s.dependency   'JWPlayerKit', '4.27.0'
   end
   s.dependency   'React-Core'
   s.static_framework = true

--- a/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
+++ b/android/src/main/java/com/jwplayer/rnjwplayer/Util.java
@@ -175,6 +175,11 @@ public class Util {
             itemBuilder.startTime(startTime);
         }
 
+        if (playlistItem.hasKey("liveSyncDuration")) {
+            double liveSyncDuration = playlistItem.getDouble("liveSyncDuration");
+            itemBuilder.liveSyncDuration(liveSyncDuration);
+        }
+
         if (playlistItem.hasKey("duration")) {
             int duration = playlistItem.getInt("duration");
             itemBuilder.duration(duration);

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -581,6 +581,13 @@ const playlistItem: JWPlaylistItem = {
   // Playback
   starttime: 0,      // Start position in seconds
   duration: 600,     // Duration in seconds
+
+  // Live streams only: target offset from the live edge in seconds.
+  // Positions playback further behind the live edge so captions have
+  // more time to process. Clamped to 5-45s by the native SDKs; omit
+  // or use 0 for default behavior. Ignored for VOD.
+  // Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
+  liveSyncDuration: 15,
   
   // Tracks
   tracks: [

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -587,7 +587,9 @@ const playlistItem: JWPlaylistItem = {
   // more time to process. A target, not a guarantee: the native SDKs
   // clamp values to 5-45s, and the stream's own hold-back may constrain
   // the result further. Omit or use 0 for default behavior. Ignored for
-  // VOD. Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
+  // VOD. Must be set on a playlist item as shown here — a root-level
+  // value is not applied on all platforms.
+  // Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
   liveSyncDuration: 15,
   
   // Tracks

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -584,9 +584,10 @@ const playlistItem: JWPlaylistItem = {
 
   // Live streams only: target offset from the live edge in seconds.
   // Positions playback further behind the live edge so captions have
-  // more time to process. Clamped to 5-45s by the native SDKs; omit
-  // or use 0 for default behavior. Ignored for VOD.
-  // Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
+  // more time to process. A target, not a guarantee: the native SDKs
+  // clamp values to 5-45s, and the stream's own hold-back may constrain
+  // the result further. Omit or use 0 for default behavior. Ignored for
+  // VOD. Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
   liveSyncDuration: 15,
   
   // Tracks

--- a/index.d.ts
+++ b/index.d.ts
@@ -303,6 +303,8 @@ declare module "@jwplayer/jwplayer-react-native" {
      * guarantee: the native SDKs clamp values to 5-45s, and the stream's own hold-back
      * may constrain the result further. Gives captions more time to process before
      * playback reaches them. Ignored for VOD.
+     *
+     * Must be set on a playlist item; a root-level value is not applied on all platforms.
      */
     liveSyncDuration?: number;
     autostart?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -298,6 +298,11 @@ declare module "@jwplayer/jwplayer-react-native" {
     tracks?: Track[];
     recommendations?: string;
     startTime?: number;
+    /**
+     * Target offset from the live edge in seconds for live streams (clamped to 5-45s natively).
+     * Gives captions more time to process before playback reaches them. Ignored for VOD.
+     */
+    liveSyncDuration?: number;
     autostart?: boolean;
     /**
      * Data to be passed to Chromecast receiver (optional and typically used for DRM implementations)

--- a/index.d.ts
+++ b/index.d.ts
@@ -299,8 +299,10 @@ declare module "@jwplayer/jwplayer-react-native" {
     recommendations?: string;
     startTime?: number;
     /**
-     * Target offset from the live edge in seconds for live streams (clamped to 5-45s natively).
-     * Gives captions more time to process before playback reaches them. Ignored for VOD.
+     * Target offset from the live edge in seconds for live streams. A target, not a
+     * guarantee: the native SDKs clamp values to 5-45s, and the stream's own hold-back
+     * may constrain the result further. Gives captions more time to process before
+     * playback reaches them. Ignored for VOD.
      */
     liveSyncDuration?: number;
     autostart?: boolean;

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1290,7 +1290,10 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
             itemBuilder.startTime(startTime)
         }
 
-        if let liveSyncDuration = item["liveSyncDuration"] as? Double {
+        // "_nativeLiveSyncDuration" is the key the SDK writes when serializing an
+        // item back out (e.g. in playlist-item event payloads), so accept both to
+        // survive a round-trip through getPlayerItem.
+        if let liveSyncDuration = (item["liveSyncDuration"] ?? item["_nativeLiveSyncDuration"]) as? Double {
             itemBuilder.liveSyncDuration(liveSyncDuration)
         }
 

--- a/ios/RNJWPlayer/RNJWPlayerView.swift
+++ b/ios/RNJWPlayer/RNJWPlayerView.swift
@@ -1290,6 +1290,10 @@ class RNJWPlayerView: UIView, JWPlayerDelegate, JWPlayerStateDelegate,
             itemBuilder.startTime(startTime)
         }
 
+        if let liveSyncDuration = item["liveSyncDuration"] as? Double {
+            itemBuilder.liveSyncDuration(liveSyncDuration)
+        }
+
         if let recommendations = item["recommendations"] as? String, let recURL = URL(string: recommendations) {
             itemBuilder.recommendations(recURL)
         }

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -310,6 +310,9 @@ export interface JWPlaylistItem {
    * platforms). 0 or negative values leave the platform default behavior
    * unchanged.
    *
+   * Must be set on a playlist item; a root-level config value is not
+   * applied on all platforms.
+   *
    * Only affects live streams; ignored for VOD content.
    * Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
    */

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -301,8 +301,14 @@ export interface JWPlaylistItem {
    *
    * Positions playback further behind the live edge, giving captions and
    * other sidecar data more time to be processed before playback reaches them.
-   * Values are clamped to 5-45 seconds by the native SDKs; 0 or negative
-   * values leave the platform default behavior unchanged.
+   *
+   * This is a target, not a guarantee. The native SDKs clamp values to the
+   * 5-45 second range, and the stream constrains the result further: a stream
+   * may advertise a minimum hold-back from the live edge that the player
+   * cannot get closer than, so values below that hold-back may have no
+   * visible effect (exact behavior below the stream minimum differs between
+   * platforms). 0 or negative values leave the platform default behavior
+   * unchanged.
    *
    * Only affects live streams; ignored for VOD content.
    * Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+

--- a/types/playlist.d.ts
+++ b/types/playlist.d.ts
@@ -295,6 +295,19 @@ export interface JWPlaylistItem {
    * Typically used for related items
    */
   duration?: number;
+
+  /**
+   * Target offset from the live edge in seconds for live streams
+   *
+   * Positions playback further behind the live edge, giving captions and
+   * other sidecar data more time to be processed before playback reaches them.
+   * Values are clamped to 5-45 seconds by the native SDKs; 0 or negative
+   * values leave the platform default behavior unchanged.
+   *
+   * Only affects live streams; ignored for VOD content.
+   * Requires iOS SDK 4.27.0+ / Android SDK 4.26.0+
+   */
+  liveSyncDuration?: number;
   
   /**
    * Whether to autostart this item


### PR DESCRIPTION

### What does this Pull Request do?

Exposes the native SDKs' `liveSyncDuration` playlist item API through the React Native bridge:

- Passes `liveSyncDuration` to `JWPlayerItemBuilder` (iOS) and `PlaylistItem.Builder` (Android) in the manual item-building paths; the JSON parser paths (`JWJSONParser` / `JsonHelper.parsePlaylistItemJson`) inherit it from the SDKs automatically
- Bumps `JWPlayerKit` to 4.27.0, the first iOS release with the API (Android is already on 4.26.0, which includes it)
- Adds `liveSyncDuration?: number` to `JWPlaylistItem` and the legacy `PlaylistItem` TypeScript types
- Documents the option in `CONFIG-REFERENCE.md`

Usage:
​```js
playlist: [{ file: 'https://example.com/live.m3u8', liveSyncDuration: 15 }]
​```

### Why is this Pull Request needed?

Live stream captions can fall out of sync near the live edge because they need more processing time than video (reported with Mux-hosted streams). Both native SDKs now expose `liveSyncDuration` to target playback further behind the live edge (applied to `AVPlayerItem.configuredTimeOffsetFromLive` on iOS and Media3 `LiveConfiguration.targetLiveOffsetMs` on Android), but React Native apps had no way to set it.


### Are there any points in the code the reviewer needs to double check?

- Values are clamped to 5-45 seconds by the native SDKs; `0`/negative means unset. The bridge intentionally passes values through unvalidated so clamping behavior stays consistent with the native SDKs.
- Only affects live streams; ignored for VOD.

### Are there any Pull Requests open in other repos which need to be merged with this?

No. The native SDK work already shipped (iOS 4.27.0, Android 4.26.0).

